### PR TITLE
Add indent and autopep8 infrastructure

### DIFF
--- a/.indent.pro
+++ b/.indent.pro
@@ -1,0 +1,24 @@
+--blank-lines-after-declarations
+--blank-lines-after-procedures
+--braces-after-func-def-line
+--braces-on-if-line
+--braces-on-struct-decl-line
+--break-after-boolean-operator
+--comment-indentation25
+--comment-line-length79
+--continue-at-parentheses
+--dont-cuddle-do-while
+--dont-cuddle-else
+--indent-level4
+--line-length79
+--no-space-after-casts
+--no-space-after-function-call-names
+--no-space-after-parentheses
+--no-tabs
+--procnames-start-lines
+--space-after-for
+--space-after-if
+--space-after-while
+--swallow-optional-blank-lines
+-T PyCFunction
+-T PyObject

--- a/.indent.pro
+++ b/.indent.pro
@@ -22,3 +22,10 @@
 --swallow-optional-blank-lines
 -T PyCFunction
 -T PyObject
+-T PyMethodDef
+-T LDAP
+-T LDAPMod
+-T LDAPMessage
+-T LDAPControl
+-T LDAPObject
+-T sasl_interact_t

--- a/Doc/contributing.rst
+++ b/Doc/contributing.rst
@@ -102,6 +102,17 @@ Specify a different one using, for example::
 
 Notable targets are:
 
+``make autoformat``
+    Automatically re-formats C and Python code to conform to Python style
+    guides (`PEP 7`_ and `PEP 8`_).
+    Note that no backups are made – please commit any other changes before
+    using this target.
+
+    Requires the ``indent`` program and the ``autopep8`` Python module.
+
+.. _PEP 7: https://www.python.org/dev/peps/pep-0007/
+.. _PEP 8: https://www.python.org/dev/peps/pep-0008/
+
 ``make lcov lcov-open``
     Generate and view test coverage for C code.
     Requires LCOV_.

--- a/Makefile
+++ b/Makefile
@@ -80,12 +80,13 @@ valgrind: build $(PYTHON_SUPP)
 	fi
 
 # Code autoformatter
-.PHONY: indent
+.PHONY: autoformat indent autopep8
+autoformat: indent autopep8
+
 indent:
 	indent Modules/*.c Modules/*.h
 	rm -f Modules/*.c~ Modules/*.h~
 
-.PHONY: autopep8
 autopep8:
 	$(PYTHON) -m autopep8 -r -i -j0 $(AUTOPEP8_OPTS) \
 	    Demo Lib Tests setup.py

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ LCOV_REPORT_OPTIONS=--show-details -no-branch-coverage \
 	--title "python-ldap LCOV report"
 SCAN_REPORT=build/scan_report
 PYTHON_SUPP=/usr/share/doc/python3-devel/valgrind-python.supp
+AUTOPEP8_OPTS=--aggressive
 
 .NOTPARALLEL:
 
@@ -13,7 +14,7 @@ all:
 
 .PHONY: clean
 clean:
-	rm -rf build dist *.egg-info $(VENV) .tox MANIFEST
+	rm -rf build dist *.egg-info .tox MANIFEST
 	rm -f .coverage .coverage.*
 	find . \( -name '*.py[co]' -or -name '*.so*' -or -name '*.dylib' \) \
 	    -delete
@@ -77,3 +78,14 @@ valgrind: build $(PYTHON_SUPP)
 	    echo "Found definitive leak, see build/valgrind.log"; \
 	    exit 1; \
 	fi
+
+# Code autoformatter
+.PHONY: indent
+indent:
+	indent Modules/*.c Modules/*.h
+	rm -f Modules/*.c~ Modules/*.h~
+
+.PHONY: autopep8
+autopep8:
+	$(PYTHON) -m autopep8 -r -i -j0 $(AUTOPEP8_OPTS) \
+	    Demo Lib Tests setup.py


### PR DESCRIPTION
* indent is a tool to auto-format C code. The ``.indent.pro`` file is based on CPython's ``Misc/indent.pro`` file. It should get us very close to PEP 7 compatible C code.
* autopep8 is a Python library to auto-format Python code. It can be used to address single pycodestyle violation, e.g. ``E121 - Fix indentation to be a multiple of four.``. See https://pypi.python.org/pypi/autopep8#features