### PR TITLE
Move install_requires into setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-pyasn1>=0.3.7
-pyasn1_modules>=0.1.5
-

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,11 @@ kwargs = dict()
 if has_setuptools:
   kwargs = dict(
     include_package_data = True,
-    install_requires = ['setuptools'],
+    install_requires = [
+        'setuptools',
+        'pyasn1 >= 0.3.7',
+        'pyasn1_modules >= 0.1.5',
+    ],
     zip_safe = False,
     python_requires = '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
   )

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,7 @@
 envlist = py27,py33,py34,py35,py36,coverage-report
 
 [testenv]
-deps =
-    coverage
-    pyasn1
-    pyasn1_modules
+deps = coverage
 commands = {envpython} -m coverage run --parallel setup.py test
 
 [testenv:coverage-report]


### PR DESCRIPTION
pip install python-ldap will now automatically install requirements and
ensure correct versions. requirements.txt is no longer needed.

Signed-off-by: Christian Heimes <cheimes@redhat.com>