### PR TITLE
Format the README

### DIFF
--- a/README
+++ b/README
@@ -102,25 +102,25 @@ These very kind people have supplied patches or suggested changes:
 
 These people contributed to Python 3 porting (at https://github.com/pyldap/):
 
-* A. Karl Kornel <akkornel at stanford.edu>
-* Alex Willmer <alex at moreati.org.uk>
-* Aymeric Augustin <aymeric.augustin at oscaro.com>
-* Bradley Baetz <bbaetz at google.com>
-* Christian Heimes <cheimes at redhat.com>
-* Dirk Mueller <dirk at dmllr.de>
-* Jon Dufresne <jon.dufresne at gmail.com>
-* Martin Basti <mbasti at redhat.com>
-* Miro Hrončok <miro at hroncok.cz>
-* Paul Aurich <paul at darkrain42.org>
-* Petr Viktorin <pviktori at redhat.com>
-* Pieterjan De Potter <pieterjan.depotter at ugent.be>
-* Raphaël Barrois <raphael.barrois at polyconseil.fr>
-* Robert Kuska <rkuska at redhat.com>
-* Stanislav Láznička <stlaz at users.noreply.github.com>
-* Tobias Bräutigam <tobias.braeutigam at gonicus.de>
-* Tom van Dijk <t.vandijk at utwente.nl>
-* Wentao Han <wentao.han at gmail.com>
-* William Brown <firstyear at redhat.com>
+* A. Karl Kornel
+* Alex Willmer
+* Aymeric Augustin
+* Bradley Baetz
+* Christian Heimes
+* Dirk Mueller
+* Jon Dufresne
+* Martin Basti
+* Miro Hrončok
+* Paul Aurich
+* Petr Viktorin
+* Pieterjan De Potter
+* Raphaël Barrois
+* Robert Kuska
+* Stanislav Láznička
+* Tobias Bräutigam
+* Tom van Dijk
+* Wentao Han
+* William Brown
 
 Thanks to all the guys on the python-ldap mailing list for
 their contributions and input into this package.

--- a/README
+++ b/README
@@ -101,6 +101,7 @@ These very kind people have supplied patches or suggested changes:
 * Matej Vela <vela at debian.org>
 
 These people contributed to Python 3 porting (at https://github.com/pyldap/):
+
 * A. Karl Kornel <akkornel at stanford.edu>
 * Alex Willmer <alex at moreati.org.uk>
 * Aymeric Augustin <aymeric.augustin at oscaro.com>
@@ -109,7 +110,7 @@ These people contributed to Python 3 porting (at https://github.com/pyldap/):
 * Dirk Mueller <dirk at dmllr.de>
 * Jon Dufresne <jon.dufresne at gmail.com>
 * Martin Basti <mbasti at redhat.com>
-* Miro Hroncok <miro at hroncok.cz>
+* Miro Hrončok <miro at hroncok.cz>
 * Paul Aurich <paul at darkrain42.org>
 * Petr Viktorin <pviktori at redhat.com>
 * Pieterjan De Potter <pieterjan.depotter at ugent.be>

--- a/README
+++ b/README
@@ -102,7 +102,7 @@ These very kind people have supplied patches or suggested changes:
 
 These people contributed to Python 3 porting (at https://github.com/pyldap/):
 
-* A. Karl Kornel
+* ​A. Karl Kornel
 * Alex Willmer
 * Aymeric Augustin
 * Bradley Baetz


### PR DESCRIPTION
* Add a blank line before the list, so ReST treats it as a list
* Remove e-mail addresses
* Just make it UTF-8 and wait if someone complains – I munged Miro's name in an effort to keep it ASCII, but forgot an `ö` and others...
* Workaround for an initial