### PR TITLE
Check for LDAP schema and slapd binaries

### DIFF
--- a/Lib/slapdtest.py
+++ b/Lib/slapdtest.py
@@ -115,7 +115,7 @@ class SlapdObject(object):
     elif os.path.isdir("/etc/ldap/schema"):
         SCHEMADIR = "/etc/ldap/schema"
     else:
-        PATH_SCHEMA_CORE = None
+        SCHEMADIR = None
     PATH_LDAPADD = os.path.join(BINDIR, 'ldapadd')
     PATH_LDAPMODIFY = os.path.join(BINDIR, 'ldapmodify')
     PATH_LDAPWHOAMI = os.path.join(BINDIR, 'ldapwhoami')
@@ -137,6 +137,17 @@ class SlapdObject(object):
         self.ldap_uri = "ldap://%s:%d/" % (LOCALHOST, self._port)
         ldapi_path = os.path.join(self.testrundir, 'ldapi')
         self.ldapi_uri = "ldapi://%s" % quote_plus(ldapi_path)
+
+    def _check_requirements(self):
+        binaries = [
+            self.PATH_LDAPADD, self.PATH_LDAPMODIFY, self.PATH_LDAPWHOAMI,
+            self.PATH_SLAPD, self.PATH_SLAPTEST
+        ]
+        for binary in binaries:
+            if not os.path.isfile(binary):
+                raise ValueError('Binary {} is missing.'.format(binary))
+        if self.SCHEMADIR is None:
+            raise ValueError('SCHEMADIR is None, ldap schemas are missing.')
 
     def setup_rundir(self):
         """
@@ -283,6 +294,7 @@ class SlapdObject(object):
         """
 
         if self._proc is None:
+            self._check_requirements()
             # prepare directory structure
             atexit.register(self.stop)
             self._cleanup_rundir()

--- a/Tests/t_bind.py
+++ b/Tests/t_bind.py
@@ -13,23 +13,22 @@ import ldap, unittest
 from slapdtest import SlapdObject
 from ldap.ldapobject import LDAPObject
 
-server = None
-
-
 class TestBinds(unittest.TestCase):
 
-    def setUp(self):
-        global server
-        if server is None:
-            server = SlapdObject()
-            server.start()
+    @classmethod
+    def setUpClass(cls):
+        cls.server = SlapdObject()
+        cls.server.start()
 
-        self.server = server
-        self.unicode_val = "abc\U0001f498def"
-        self.unicode_val_bytes = self.unicode_val.encode('utf-8')
+        cls.unicode_val = "abc\U0001f498def"
+        cls.unicode_val_bytes = cls.unicode_val.encode('utf-8')
 
-        self.dn_unicode = "CN=" + self.unicode_val
-        self.dn_bytes = self.dn_unicode.encode('utf-8')
+        cls.dn_unicode = "CN=" + cls.unicode_val
+        cls.dn_bytes = cls.dn_unicode.encode('utf-8')
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.server.stop()
 
     def _get_ldapobject(self, bytes_mode=None):
         l = LDAPObject(self.server.ldap_uri, bytes_mode=bytes_mode)


### PR DESCRIPTION
Integration tests depend on openldap client and server binaries. Fail
with a human readable message in case a tool or schema is missing.

Signed-off-by: Christian Heimes <cheimes@redhat.com>