### PR TITLE
Fix type conversion in decode_page_control

### DIFF
--- a/Lib/ldap/controls/pagedresults.py
+++ b/Lib/ldap/controls/pagedresults.py
@@ -44,7 +44,7 @@ class SimplePagedResultsControl(RequestControl,ResponseControl):
   def decodeControlValue(self,encodedControlValue):
     decodedValue,_ = decoder.decode(encodedControlValue,asn1Spec=PagedResultsControlValue())
     self.size = int(decodedValue.getComponentByName('size'))
-    self.cookie = str(decodedValue.getComponentByName('cookie'))
+    self.cookie = bytes(decodedValue.getComponentByName('cookie'))
 
 
 KNOWN_RESPONSE_CONTROLS[SimplePagedResultsControl.controlType] = SimplePagedResultsControl

--- a/Modules/ldapcontrol.c
+++ b/Modules/ldapcontrol.c
@@ -304,7 +304,7 @@ decode_rfc2696(PyObject *self, PyObject *args)
     struct berval ldctl_value;
     ber_tag_t tag;
     struct berval *cookiep;
-    unsigned long count;
+    unsigned long count = 0;
     Py_ssize_t ldctl_value_len;
 
     if (!PyArg_ParseTuple(args, "s#:decode_page_control",
@@ -324,7 +324,7 @@ decode_rfc2696(PyObject *self, PyObject *args)
         goto endlbl;
     }
 
-    res = Py_BuildValue("(lO&)", count, LDAPberval_to_object, cookiep);
+    res = Py_BuildValue("(kO&)", count, LDAPberval_to_object, cookiep);
     ber_bvfree(cookiep);
 
  endlbl:

--- a/Tests/__init__.py
+++ b/Tests/__init__.py
@@ -21,3 +21,4 @@ from . import t_ldapobject
 from . import t_edit
 from . import t_ldap_schema_subentry
 from . import t_untested_mods
+from . import t_ldap_controls_libldap

--- a/Tests/t_ldap_controls_libldap.py
+++ b/Tests/t_ldap_controls_libldap.py
@@ -1,0 +1,54 @@
+import os
+import unittest
+
+# Switch off processing .ldaprc or ldap.conf before importing _ldap
+os.environ['LDAPNOINIT'] = '1'
+
+import ldap
+from ldap.controls import pagedresults
+from ldap.controls import libldap
+
+
+PRC_BER = b'0\x0b\x02\x01\x05\x04\x06cookie'
+SIZE = 5
+COOKIE = b'cookie'
+
+
+class TestLibldapControls(unittest.TestCase):
+    def test_pagedresults_encode(self):
+        pr = pagedresults.SimplePagedResultsControl(
+            size=SIZE, cookie=COOKIE
+        )
+        lib = libldap.SimplePagedResultsControl(
+            size=SIZE, cookie=COOKIE
+        )
+        self.assertEqual(pr.encodeControlValue(), lib.encodeControlValue())
+        self.assertEqual(pr.encodeControlValue(), PRC_BER)
+
+    def test_pagedresults_decode(self):
+        pr = pagedresults.SimplePagedResultsControl()
+        pr.decodeControlValue(PRC_BER)
+        self.assertEqual(pr.size, SIZE)
+        # LDAPString (OCTET STRING)
+        self.assertIsInstance(pr.cookie, bytes)
+        self.assertEqual(pr.cookie, COOKIE)
+
+        lib = libldap.SimplePagedResultsControl()
+        lib.decodeControlValue(PRC_BER)
+        self.assertEqual(lib.size, SIZE)
+        self.assertIsInstance(lib.cookie, bytes)
+        self.assertEqual(lib.cookie, COOKIE)
+
+    def test_matchedvalues(self):
+        mvc = libldap.MatchedValuesControl()
+        # unverified
+        self.assertEqual(mvc.encodeControlValue(), b'0\r\x87\x0bobjectClass')
+
+    def test_assertioncontrol(self):
+        ac = libldap.AssertionControl()
+        # unverified
+        self.assertEqual(ac.encodeControlValue(), b'\x87\x0bobjectClass')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tests/t_untested_mods.py
+++ b/Tests/t_untested_mods.py
@@ -2,7 +2,6 @@
 import ldap.async
 import ldap.controls.deref
 import ldap.controls.openldap
-import ldap.controls.pagedresults
 import ldap.controls.ppolicy
 import ldap.controls.psearch
 import ldap.controls.pwdpolicy


### PR DESCRIPTION
The RFC 2696 function decode_page_control() had a conversion error.
`count` is an unsigned long. The correct format character for
Py_BuildValue() is 'k', not 'l'. The problem caused the function to to return
wrong value every now and then. I have seen 140728898420741 or
140728898420741 instead of 5.

Add tests for all four uncovered helper functions.

Signed-off-by: Christian Heimes <cheimes@redhat.com>