### PR TITLE
Fix resource leaks in error cases

### DIFF
--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -361,8 +361,10 @@ l_ldap_unbind_ext( LDAPObject* self, PyObject* args )
     }
 
     if (!PyNone_Check(clientctrls)) {
-        if (!LDAPControls_from_object(clientctrls, &client_ldcs))
+        if (!LDAPControls_from_object(clientctrls, &client_ldcs)) {
+            LDAPControl_List_DEL( server_ldcs );
             return NULL;
+        }
     }
 
     LDAP_BEGIN_ALLOW_THREADS( self );
@@ -402,8 +404,10 @@ l_ldap_abandon_ext( LDAPObject* self, PyObject* args )
     }
 
     if (!PyNone_Check(clientctrls)) {
-        if (!LDAPControls_from_object(clientctrls, &client_ldcs))
+        if (!LDAPControls_from_object(clientctrls, &client_ldcs)) {
+            LDAPControl_List_DEL( server_ldcs );
             return NULL;
+        }
     }
 
     LDAP_BEGIN_ALLOW_THREADS( self );
@@ -444,13 +448,18 @@ l_ldap_add_ext( LDAPObject* self, PyObject *args )
         return NULL;
 
     if (!PyNone_Check(serverctrls)) {
-        if (!LDAPControls_from_object(serverctrls, &server_ldcs))
+        if (!LDAPControls_from_object(serverctrls, &server_ldcs)) {
+            LDAPMods_DEL( mods );
             return NULL;
+        }
     }
 
     if (!PyNone_Check(clientctrls)) {
-        if (!LDAPControls_from_object(clientctrls, &client_ldcs))
+        if (!LDAPControls_from_object(clientctrls, &client_ldcs)) {
+            LDAPMods_DEL( mods );
+            LDAPControl_List_DEL( server_ldcs );
             return NULL;
+        }
     }
 
     LDAP_BEGIN_ALLOW_THREADS( self );
@@ -492,8 +501,10 @@ l_ldap_simple_bind( LDAPObject* self, PyObject* args )
     }
 
     if (!PyNone_Check(clientctrls)) {
-        if (!LDAPControls_from_object(clientctrls, &client_ldcs))
+        if (!LDAPControls_from_object(clientctrls, &client_ldcs)) {
+            LDAPControl_List_DEL( server_ldcs );
             return NULL;
+        }
     }
 
     LDAP_BEGIN_ALLOW_THREADS( self );
@@ -641,8 +652,10 @@ l_ldap_sasl_bind_s( LDAPObject* self, PyObject* args )
             return NULL;
     }
     if (!PyNone_Check(clientctrls)) {
-        if (!LDAPControls_from_object(clientctrls, &client_ldcs))
+        if (!LDAPControls_from_object(clientctrls, &client_ldcs)) {
+            LDAPControl_List_DEL( server_ldcs );
             return NULL;
+        }
     }
 
     LDAP_BEGIN_ALLOW_THREADS( self );
@@ -705,8 +718,10 @@ l_ldap_sasl_interactive_bind_s( LDAPObject* self, PyObject* args )
     }
 
     if (!PyNone_Check(clientctrls)) {
-        if (!LDAPControls_from_object(clientctrls, &client_ldcs))
+        if (!LDAPControls_from_object(clientctrls, &client_ldcs)) {
+            LDAPControl_List_DEL( server_ldcs );
             return NULL;
+        }
     }
 
     /* now we extract the sasl mechanism from the SASL Object */
@@ -765,8 +780,10 @@ l_ldap_cancel( LDAPObject* self, PyObject* args )
     }
 
     if (!PyNone_Check(clientctrls)) {
-        if (!LDAPControls_from_object(clientctrls, &client_ldcs))
+        if (!LDAPControls_from_object(clientctrls, &client_ldcs)) {
+            LDAPControl_List_DEL( server_ldcs );
             return NULL;
+        }
     }
 
     LDAP_BEGIN_ALLOW_THREADS( self );
@@ -811,8 +828,10 @@ l_ldap_compare_ext( LDAPObject* self, PyObject *args )
     }
 
     if (!PyNone_Check(clientctrls)) {
-        if (!LDAPControls_from_object(clientctrls, &client_ldcs))
+        if (!LDAPControls_from_object(clientctrls, &client_ldcs)) {
+            LDAPControl_List_DEL( server_ldcs );
             return NULL;
+        }
     }
 
     LDAP_BEGIN_ALLOW_THREADS( self );
@@ -852,8 +871,10 @@ l_ldap_delete_ext( LDAPObject* self, PyObject *args )
     }
 
     if (!PyNone_Check(clientctrls)) {
-        if (!LDAPControls_from_object(clientctrls, &client_ldcs))
+        if (!LDAPControls_from_object(clientctrls, &client_ldcs)) {
+            LDAPControl_List_DEL( server_ldcs );
             return NULL;
+        }
     }
 
     LDAP_BEGIN_ALLOW_THREADS( self );
@@ -894,13 +915,18 @@ l_ldap_modify_ext( LDAPObject* self, PyObject *args )
         return NULL;
 
     if (!PyNone_Check(serverctrls)) {
-        if (!LDAPControls_from_object(serverctrls, &server_ldcs))
+        if (!LDAPControls_from_object(serverctrls, &server_ldcs)) {
+            LDAPMods_DEL( mods );
             return NULL;
+        }
     }
 
     if (!PyNone_Check(clientctrls)) {
-        if (!LDAPControls_from_object(clientctrls, &client_ldcs))
+        if (!LDAPControls_from_object(clientctrls, &client_ldcs)) {
+            LDAPMods_DEL( mods );
+            LDAPControl_List_DEL( server_ldcs );
             return NULL;
+        }
     }
 
     LDAP_BEGIN_ALLOW_THREADS( self );
@@ -944,8 +970,10 @@ l_ldap_rename( LDAPObject* self, PyObject *args )
     }
 
     if (!PyNone_Check(clientctrls)) {
-        if (!LDAPControls_from_object(clientctrls, &client_ldcs))
+        if (!LDAPControls_from_object(clientctrls, &client_ldcs)) {
+            LDAPControl_List_DEL( server_ldcs );
             return NULL;
+        }
     }
 
     LDAP_BEGIN_ALLOW_THREADS( self );
@@ -1137,13 +1165,18 @@ l_ldap_search_ext( LDAPObject* self, PyObject* args )
     }
 
     if (!PyNone_Check(serverctrls)) {
-        if (!LDAPControls_from_object(serverctrls, &server_ldcs))
+        if (!LDAPControls_from_object(serverctrls, &server_ldcs)) {
+            free_attrs( &attrs,  attrs_seq);
             return NULL;
+        }
     }
 
     if (!PyNone_Check(clientctrls)) {
-        if (!LDAPControls_from_object(clientctrls, &client_ldcs))
+        if (!LDAPControls_from_object(clientctrls, &client_ldcs)) {
+            free_attrs( &attrs,  attrs_seq);
+            LDAPControl_List_DEL( server_ldcs );
             return NULL;
+        }
     }
 
     LDAP_BEGIN_ALLOW_THREADS( self );
@@ -1187,8 +1220,10 @@ l_ldap_whoami_s( LDAPObject* self, PyObject* args )
     }
 
     if (!PyNone_Check(clientctrls)) {
-        if (!LDAPControls_from_object(clientctrls, &client_ldcs))
+        if (!LDAPControls_from_object(clientctrls, &client_ldcs)) {
+            LDAPControl_List_DEL( server_ldcs );
             return NULL;
+        }
     }
 
     LDAP_BEGIN_ALLOW_THREADS( self );
@@ -1295,8 +1330,10 @@ l_ldap_passwd( LDAPObject* self, PyObject *args )
     }
 
     if (!PyNone_Check(clientctrls)) {
-        if (!LDAPControls_from_object(clientctrls, &client_ldcs))
+        if (!LDAPControls_from_object(clientctrls, &client_ldcs)) {
+            LDAPControl_List_DEL( server_ldcs );
             return NULL;
+        }
     }
 
     LDAP_BEGIN_ALLOW_THREADS( self );
@@ -1345,8 +1382,10 @@ l_ldap_extended_operation( LDAPObject* self, PyObject *args )
     }
 
     if (!PyNone_Check(clientctrls)) {
-        if (!LDAPControls_from_object(clientctrls, &client_ldcs))
+        if (!LDAPControls_from_object(clientctrls, &client_ldcs)) {
+            LDAPControl_List_DEL( server_ldcs );
             return NULL;
+        }
     }
 
     LDAP_BEGIN_ALLOW_THREADS( self );


### PR DESCRIPTION
On several occasions LDAPObject methods did not clean up LDAPControls
and other resources when LDAPControls_from_object() fails. This bug
would lead to memory leaks in case a server control or client control
could not be handled correctly.

Closes: #18
Signed-off-by: Christian Heimes <cheimes@redhat.com>