### PR TITLE
no-op for un-evaluatable items in globals

### DIFF
--- a/Lib/ldap/schema/subentry.py
+++ b/Lib/ldap/schema/subentry.py
@@ -12,7 +12,10 @@ SCHEMA_CLASS_MAPPING = ldap.cidict.cidict()
 SCHEMA_ATTR_MAPPING = {}
 
 for _name in dir():
-  o = eval(_name)
+  try:
+    o = eval(_name)
+  except SyntaxError:
+    continue
   if hasattr(o,'schema_attribute'):
     SCHEMA_CLASS_MAPPING[o.schema_attribute] = o
     SCHEMA_ATTR_MAPPING[o] = o.schema_attribute


### PR DESCRIPTION
This pull request carries out what was suggested in the email:

https://mail.python.org/pipermail/python-ldap/2016q3/003789.html

The project that I am working on has had to keep the version of pytest pinned ever since encountering the problem mentioned here, because pytest puts decorators in the pattern of `@something` as a key that shows up inside of `dir()`. A major takeaway is that you should not count on keys inside of `dir()` to be something that can be evaluated in all environments.

https://github.com/ansible/awx/blob/devel/requirements/requirements_dev.txt#L8

If you could make this change, no existing workflow should be affected, and we will be able to upgrade pytest as soon as a new release of pytest-ldap is cut.

My alternative solution is that this diff would also suffice:

```diff
 SCHEMA_ATTR_MAPPING = {}
 
 for _name in dir():
-  o = eval(_name)
+  o = globals()[_name]
   if hasattr(o,'schema_attribute'):
     SCHEMA_CLASS_MAPPING[o.schema_attribute] = o
     SCHEMA_ATTR_MAPPING[o] = o.schema_attribute
```

By the way, thank you for taking over management of this project. No one responded to my email, but I am delighted to be able to make the pull request directly now.