### PR TITLE
Fix syntax of find -delete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ all:
 clean:
 	rm -rf build dist *.egg-info $(VENV) .tox MANIFEST
 	rm -f .coverage .coverage.*
-	find . -name '*.py[co]' -or -name '*.so*' -or -name '*.dylib' -delete
+	find . \( -name '*.py[co]' -or -name '*.so*' -or -name '*.dylib' \) \
+	    -delete
 	find . -depth -name __pycache__ -exec rm -rf {} \;
 
 # LCOV report (measuring test coverage for C code)


### PR DESCRIPTION
With -delete, the matches must be grouped. Otherwise -delete is only
executed for the last matcher.

Signed-off-by: Christian Heimes <cheimes@redhat.com>