### PR TITLE
Omit SysLogHandler when /dev/log does not exist

### DIFF
--- a/Lib/slapdtest.py
+++ b/Lib/slapdtest.py
@@ -59,7 +59,7 @@ def combined_logger(
             pass
     # for writing to syslog
     new_logger = logging.getLogger(log_name)
-    if sys_log_format:
+    if sys_log_format and os.path.exists('/dev/log'):
         my_syslog_formatter = logging.Formatter(
             fmt=' '.join((log_name, sys_log_format)))
         my_syslog_handler = logging.handlers.SysLogHandler(


### PR DESCRIPTION
slaptests use SysLogHandler() to write logs to syslog. Don't create a
SysLogHandler when /dev/log does not exist. This fixes a bug when
building and testing python-ldap in containers or restricted build
environments.

Signed-off-by: Christian Heimes <cheimes@redhat.com>