### PR TITLE
Lib: Avoid eval() for getting module-level variables

### DIFF
--- a/Lib/ldap/schema/subentry.py
+++ b/Lib/ldap/schema/subentry.py
@@ -11,8 +11,7 @@ from ldap.schema.models import *
 SCHEMA_CLASS_MAPPING = ldap.cidict.cidict()
 SCHEMA_ATTR_MAPPING = {}
 
-for _name in dir():
-  o = eval(_name)
+for o in list(vars().values()):
   if hasattr(o,'schema_attribute'):
     SCHEMA_CLASS_MAPPING[o.schema_attribute] = o
     SCHEMA_ATTR_MAPPING[o] = o.schema_attribute


### PR DESCRIPTION
Alternate version of #25 that avoids `eval()` entirely.

Issue for a more proper fix filed here: https://github.com/python-ldap/python-ldap/issues/34

Fixes: https://github.com/python-ldap/python-ldap/pull/25