### PR TITLE
C extension reference leak testing

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -24,3 +24,37 @@ Quick build instructions:
     edit setup.cfg (see Build/ for platform-specific examples)
     python setup.py build
     python setup.py install
+
+--------------------
+Reference leak tests
+--------------------
+
+Reference leak tests require a pydebug build of CPython and pytest with
+pytest-leaks plugin. A pydebug build has a global reference counter, which
+keeps track of all reference increments and decrements. The leak plugin runs
+each tests multiple times and checks if the reference count increases.
+
+Download and compile pydebug build
+----------------------------------
+
+- curl -O https://www.python.org/ftp/python/3.6.3/Python-3.6.3.tar.xz
+- tar xJf Python-3.6.3.tar.xz
+- cd Python-3.6.3
+- ./configure --with-pydebug
+- make
+
+Create virtual env
+------------------
+
+- ./python -m venv /tmp/refleak
+- /tmp/refleak/bin/pip install pytest pytest-leaks
+
+Run refleak tests
+-----------------
+
+- cd path/to/python-ldap
+- /tmp/refleak/bin/pip install --upgrade .
+- /tmp/refleak/bin/pytest -v -R: Tests/t_*.py
+
+Run ``/tmp/refleak/bin/pip install --upgrade .`` every time a file outside
+of ``Tests/`` is modified.

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -51,6 +51,40 @@ class TestLdapCExtension(SlapdTestCase):
             ])
         )
 
+    def setUp(self):
+        super(TestLdapCExtension, self).setUp()
+        self._writesuffix = None
+
+    def tearDown(self):
+        # cleanup test subtree
+        if self._writesuffix is not None:
+            self.server.ldapdelete(self._writesuffix, recursive=True)
+        super(TestLdapCExtension, self).tearDown()
+
+    @property
+    def writesuffix(self):
+        """Initialize writesuffix on demand
+
+        Creates a clean subtree for tests that write to slapd. ldapdelete
+        is not able to delete a Root DSE, therefore we need a temporary
+        work space.
+
+        :return: DN
+        """
+        if self._writesuffix is not None:
+            return self._writesuffix
+        self._writesuffix = 'ou=write tests,%s' % self.server.suffix
+        # Add writeable subtree
+        self.server.ldapadd(
+            "\n".join([
+                'dn: ' + self._writesuffix,
+                'objectClass: organizationalUnit',
+                'ou:' + self._writesuffix.split(',')[0][3:],
+                ''
+            ])
+        )
+        return self._writesuffix
+
     def _open_conn(self, bind=True):
         """
         Starts a server, and returns a LDAPObject bound to it
@@ -278,7 +312,7 @@ class TestLdapCExtension(SlapdTestCase):
         """
         l = self._open_conn()
         m = l.add_ext(
-            "cn=Foo," + self.server.suffix,
+            "cn=Foo," + self.writesuffix,
             [
                 ('objectClass', b'organizationalRole'),
                 ('cn', b'Foo'),
@@ -292,7 +326,7 @@ class TestLdapCExtension(SlapdTestCase):
         self.assertEqual(msgid, m)
         self.assertEqual(ctrls, [])
         # search for it back
-        m = l.search_ext(self.server.suffix, _ldap.SCOPE_SUBTREE, '(cn=Foo)')
+        m = l.search_ext(self.writesuffix, _ldap.SCOPE_SUBTREE, '(cn=Foo)')
         result, pmsg, msgid, ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         # Expect to get the objects
         self.assertEqual(result, _ldap.RES_SEARCH_RESULT)
@@ -302,7 +336,7 @@ class TestLdapCExtension(SlapdTestCase):
         self.assertEqual(
             pmsg[0],
             (
-                'cn=Foo,'+self.server.suffix,
+                'cn=Foo,'+self.writesuffix,
                 {
                     'objectClass': [b'organizationalRole'],
                     'cn': [b'Foo'],
@@ -317,7 +351,7 @@ class TestLdapCExtension(SlapdTestCase):
         """
         l = self._open_conn()
         # first, add an object with a field we can compare on
-        dn = "cn=CompareTest," + self.server.suffix
+        dn = "cn=CompareTest," + self.writesuffix
         m = l.add_ext(
             dn,
             [
@@ -371,7 +405,7 @@ class TestLdapCExtension(SlapdTestCase):
     def test_delete(self):
         l = self._open_conn()
         # first, add an object we will delete
-        dn = "cn=Deleteme,"+self.server.suffix
+        dn = "cn=Deleteme,"+self.writesuffix
         m = l.add_ext(
             dn,
             [
@@ -395,7 +429,7 @@ class TestLdapCExtension(SlapdTestCase):
 
         # try deleting an object that doesn't exist
         m = l.modify_ext(
-            "cn=DoesNotExist,"+self.server.suffix,
+            "cn=DoesNotExist,"+self.writesuffix,
             [
                 (_ldap.MOD_ADD, 'description', [b'blah']),
             ]
@@ -432,7 +466,7 @@ class TestLdapCExtension(SlapdTestCase):
         """
         l = self._open_conn()
         # first, add an object we will delete
-        dn = "cn=AddToMe,"+self.server.suffix
+        dn = "cn=AddToMe,"+self.writesuffix
         m = l.add_ext(
             dn,
             [
@@ -458,7 +492,7 @@ class TestLdapCExtension(SlapdTestCase):
         self.assertEqual(msgid, m)
         self.assertEqual(ctrls, [])
         # search for it back
-        m = l.search_ext(self.server.suffix, _ldap.SCOPE_SUBTREE, '(cn=AddToMe)')
+        m = l.search_ext(self.writesuffix, _ldap.SCOPE_SUBTREE, '(cn=AddToMe)')
         result, pmsg, msgid, ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         # Expect to get the objects
         self.assertEqual(result, _ldap.RES_SEARCH_RESULT)
@@ -472,7 +506,7 @@ class TestLdapCExtension(SlapdTestCase):
 
     def test_rename(self):
         l = self._open_conn()
-        dn = "cn=RenameMe,"+self.server.suffix
+        dn = "cn=RenameMe,"+self.writesuffix
         m = l.add_ext(
             dn,
             [
@@ -493,7 +527,7 @@ class TestLdapCExtension(SlapdTestCase):
         self.assertEqual(ctrls, [])
 
         # make sure the old one is gone
-        m = l.search_ext(self.server.suffix, _ldap.SCOPE_SUBTREE, '(cn=RenameMe)')
+        m = l.search_ext(self.writesuffix, _ldap.SCOPE_SUBTREE, '(cn=RenameMe)')
         result, pmsg, msgid, ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEqual(result, _ldap.RES_SEARCH_RESULT)
         self.assertEqual(len(pmsg), 0) # expect no results
@@ -501,8 +535,8 @@ class TestLdapCExtension(SlapdTestCase):
         self.assertEqual(ctrls, [])
 
         # check that the new one looks right
-        dn2 = "cn=IAmRenamed,"+self.server.suffix
-        m = l.search_ext(self.server.suffix, _ldap.SCOPE_SUBTREE, '(cn=IAmRenamed)')
+        dn2 = "cn=IAmRenamed,"+self.writesuffix
+        m = l.search_ext(self.writesuffix, _ldap.SCOPE_SUBTREE, '(cn=IAmRenamed)')
         result, pmsg, msgid, ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEqual(result, _ldap.RES_SEARCH_RESULT)
         self.assertEqual(msgid, m)
@@ -512,7 +546,7 @@ class TestLdapCExtension(SlapdTestCase):
         self.assertEqual(pmsg[0][1]['cn'], [b'IAmRenamed'])
 
         # create the container
-        containerDn = "ou=RenameContainer,"+self.server.suffix
+        containerDn = "ou=RenameContainer,"+self.writesuffix
         m = l.add_ext(
             containerDn,
             [
@@ -535,18 +569,18 @@ class TestLdapCExtension(SlapdTestCase):
         self.assertEqual(ctrls, [])
 
         # make sure dn2 is gone
-        m = l.search_ext(self.server.suffix, _ldap.SCOPE_SUBTREE, '(cn=IAmRenamed)')
+        m = l.search_ext(self.writesuffix, _ldap.SCOPE_SUBTREE, '(cn=IAmRenamed)')
         result, pmsg, msgid, ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEqual(result, _ldap.RES_SEARCH_RESULT)
         self.assertEqual(len(pmsg), 0) # expect no results
         self.assertEqual(msgid, m)
         self.assertEqual(ctrls, [])
 
-        m = l.search_ext(self.server.suffix, _ldap.SCOPE_SUBTREE, '(objectClass=*)')
+        m = l.search_ext(self.writesuffix, _ldap.SCOPE_SUBTREE, '(objectClass=*)')
         result, pmsg, msgid, ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
 
         # make sure dn3 is there
-        m = l.search_ext(self.server.suffix, _ldap.SCOPE_SUBTREE, '(cn=IAmRenamedAgain)')
+        m = l.search_ext(self.writesuffix, _ldap.SCOPE_SUBTREE, '(cn=IAmRenamedAgain)')
         result, pmsg, msgid, ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
         self.assertEqual(result, _ldap.RES_SEARCH_RESULT)
         self.assertEqual(msgid, m)
@@ -588,7 +622,7 @@ class TestLdapCExtension(SlapdTestCase):
     def test_passwd(self):
         l = self._open_conn()
         # first, create a user to change password on
-        dn = "cn=PasswordTest," + self.server.suffix
+        dn = "cn=PasswordTest," + self.writesuffix
         m = l.add_ext(
             dn,
             [

--- a/Tests/t_edit.py
+++ b/Tests/t_edit.py
@@ -83,6 +83,12 @@ class EditionTests(unittest.TestCase):
             ("cn=Added,ou=Container," + base,
                 {'cn': [b'Added'], 'objectClass': [b'organizationalRole']}),
         ])
+        # Delete object
+        self.ldap.delete_s(dn)
+        result = self.ldap.search_s(
+            base, ldap.SCOPE_SUBTREE, '(cn=Added)', ['*']
+        )
+        self.assertEqual(result, [])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add documentation how to run refleak tests with pydebug build of
CPython and pytest-refleak. Refleak testing runs each unit test multiple
times. Some small changes are required to clean up after each test cycle
and to avoid extra references.

* Only create logging structure for SlapdObject once. The logging
  framework creates reference cycles that cause false positives.
* Clean up and remove atexit handlers in SlapdObject.stop()
* Remove new entries at the end of each test, either with an
  explicit delete_s() or an write area, which is removed in tearDown().

Signed-off-by: Christian Heimes <cheimes@redhat.com>