### PR TITLE
Don't define search path for includes and libs

### DIFF
--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -13,11 +13,7 @@
 #include "options.h"
 
 #ifdef HAVE_SASL
-#ifdef __APPLE__
 #include <sasl/sasl.h>
-#else
-#include <sasl.h>
-#endif
 #endif
 
 static void free_attrs(char***, PyObject*);

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,9 +5,10 @@
 # for wrapping OpenLDAP 2 libs
 [_ldap]
 
-# Define extra include and library dirs if needed
-library_dirs = /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64
-include_dirs = /usr/include /usr/include/sasl /usr/local/include /usr/local/include/sasl
+# Define extra include and library dirs if needed. distutils adds non
+# standard library_dirs as rpath.
+# library_dirs = /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64
+# include_dirs = /usr/include /usr/include/sasl /usr/local/include /usr/local/include/sasl
 
 # These defines needs OpenLDAP built with
 # ./configure --with-cyrus-sasl --with-tls

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@
 # Define extra include and library dirs if needed. distutils adds non
 # standard library_dirs as rpath.
 # library_dirs = /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64
-# include_dirs = /usr/include /usr/include/sasl /usr/local/include /usr/local/include/sasl
+# include_dirs = /usr/include /usr/local/include
 
 # These defines needs OpenLDAP built with
 # ./configure --with-cyrus-sasl --with-tls


### PR DESCRIPTION
Compilers' and linkers' default search paths are fine on modern Linux. The
custom search path was wrong on 32bit platforms anyway. When library_dirs is
defined, distutils also adds rpath to the shared library. An rpath
should not be added by default.

I only commented out the configuration stanzes to keep them as example.

Closes: https://github.com/python-ldap/python-ldap/issues/30
Signed-off-by: Christian Heimes <cheimes@redhat.com>