### PR TITLE
Use standard PyVarObject_HEAD_INIT() call

### DIFF
--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -1434,12 +1434,7 @@ static PyMethodDef methods[] = {
 /* type entry */
 
 PyTypeObject LDAP_Type = {
-#if defined(MS_WINDOWS) || defined(__CYGWIN__)
-        /* see http://www.python.org/doc/FAQ.html#3.24 */
         PyVarObject_HEAD_INIT(NULL, 0)
-#else /* ! MS_WINDOWS */
-        PyVarObject_HEAD_INIT(&PyType_Type, 0)
-#endif /* MS_WINDOWS */
         "LDAP",                 /*tp_name*/
         sizeof(LDAPObject),     /*tp_basicsize*/
         0,                      /*tp_itemsize*/

--- a/Modules/ldapmodule.c
+++ b/Modules/ldapmodule.c
@@ -41,9 +41,9 @@ PyObject* init_ldap_module()
 {
 	PyObject *m, *d;
 
-#if defined(MS_WINDOWS) || defined(__CYGWIN__)
-	LDAP_Type.ob_type = &PyType_Type;
-#endif
+	/* Initialize LDAP class */
+	if (PyType_Ready(&LDAP_Type) < 0)
+		return NULL;
 
 	/* Create the module and add the functions */
 #if PY_MAJOR_VERSION >= 3
@@ -58,8 +58,6 @@ PyObject* init_ldap_module()
 #else
 	m = Py_InitModule("_ldap", methods);
 #endif
-
-        PyType_Ready(&LDAP_Type);
 
 	/* Add some symbolic constants to the module */
 	d = PyModule_GetDict(m);


### PR DESCRIPTION
PyType_Ready() takes care of the base type for us. Also check PyType_Ready()
result for error.

Signed-off-by: Christian Heimes <cheimes@redhat.com>