### PR TITLE
Doc: Link to documentation for older versions

### DIFF
--- a/Doc/index.rst
+++ b/Doc/index.rst
@@ -45,7 +45,11 @@ The documentation for python-ldap 3.x is hosted at `Read the Docs`_.
 You can switch between versions of the library, or download PDF or HTML
 versions for offline use, using the right sidebar.
 
+Documentation for some older versions is available for download at the
+`GitHub release page`_.
+
 .. _Read the Docs: http://python-ldap.readthedocs.io/en/latest/
+.. _GitHub release page: https://github.com/python-ldap/python-ldap/releases
 
 
 Contents


### PR DESCRIPTION
`python-ldap.org` includes a link to pre-built documentation (although it was not updated recently). This will be lost with the switch to Read the Docs – it's not set up to serve zipfiles, and older branches don't build there.
I've built docs for latest 2.4.x and 2.5.x releases and uploaded them to GitHub. This PR makes the documentation point there.
