### PR TITLE
Fix several compiler warnings and make warnings fatal errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,14 @@ matrix:
     - python: 3.6
       env: TOXENV=doc
 
+env:
+    global:
+        # -Wno-int-in-bool-context: don't complain about PyMem_MALLOC()
+        # -Werror: turn all warnings into fatal errors
+        - CFLAGS="-Wno-int-in-bool-context -Werror"
+        # pass CFLAGS and WITH_GCOV to tox tasks
+        - TOX_TESTENV_PASSENV="CFLAGS WITH_GCOV"
+
 install:
   - pip install "pip>=7.1.0"
   - pip install tox-travis tox codecov coverage

--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -112,7 +112,8 @@ Tuple_to_LDAPMod( PyObject* tup, int no_op )
     Py_ssize_t i, len, nstrs;
 
     if (!PyTuple_Check(tup)) {
-        return LDAPerror_TypeError("expected a tuple", tup);
+        LDAPerror_TypeError("expected a tuple", tup);
+        return NULL;
     }
 
     if (no_op) {
@@ -209,13 +210,15 @@ List_to_LDAPMods( PyObject *list, int no_op ) {
     PyObject *item;
 
     if (!PySequence_Check(list)) {
-        return LDAPerror_TypeError("expected list of tuples", list);
+        LDAPerror_TypeError("expected list of tuples", list);
+        return NULL;
     }
 
     len = PySequence_Length(list);
 
     if (len < 0) {
-        return LDAPerror_TypeError("expected list of tuples", list);
+        LDAPerror_TypeError("expected list of tuples", list);
+        return NULL;
     }
 
     lms = PyMem_NEW(LDAPMod *, len + 1);

--- a/Modules/ldapcontrol.c
+++ b/Modules/ldapcontrol.c
@@ -4,6 +4,7 @@
 #include "LDAPObject.h"
 #include "ldapcontrol.h"
 #include "berval.h"
+#include "constants.h"
 
 #include "lber.h"
 

--- a/Modules/ldapcontrol.c
+++ b/Modules/ldapcontrol.c
@@ -71,7 +71,8 @@ Tuple_to_LDAPControl( PyObject* tup )
     Py_ssize_t len;
 
     if (!PyTuple_Check(tup)) {
-      return LDAPerror_TypeError("expected a tuple", tup);
+      LDAPerror_TypeError("expected a tuple", tup);
+      return NULL;
     }
 
     if (!PyArg_ParseTuple( tup, "sbO", &oid, &iscritical, &bytes ))

--- a/Modules/ldapmodule.c
+++ b/Modules/ldapmodule.c
@@ -37,7 +37,7 @@ static PyMethodDef methods[]  = {
 
 
 /* Common initialization code */
-PyObject* init_ldap_module()
+PyObject* init_ldap_module(void)
 {
 	PyObject *m, *d;
 


### PR DESCRIPTION
* Correct return LDAPerror_TypeError(). LDAPerror_TypeError() returns ``(PyObject *)NULL``. Some functions don't return a ``PyObject*`` so technically it's wrong to return ``(PyObject *)NULL``. Return NULL instead.
* Fix implicit declaration of error functions, ldapcontrol.c was missing include of constants.h that defines LDAPerr() and LDAPerror().
* Make init_ldap_module definition a strict prototype
* Travis: Turn compiler warnings into fatal errors