### PR TITLE
Fix declaration after statement for C90

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,8 @@ env:
     global:
         # -Wno-int-in-bool-context: don't complain about PyMem_MALLOC()
         # -Werror: turn all warnings into fatal errors
-        - CFLAGS="-Wno-int-in-bool-context -Werror"
+        # -Werror=declaration-after-statement: strict ISO C90
+        - CFLAGS="-std=c90 -Wno-int-in-bool-context -Werror -Werror=declaration-after-statement"
         # pass CFLAGS and WITH_GCOV to tox tasks
         - TOX_TESTENV_PASSENV="CFLAGS WITH_GCOV"
 

--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -998,6 +998,9 @@ l_ldap_result4( LDAPObject* self, PyObject *args )
     int res_msgid = 0;
     char *retoid = 0;
     PyObject *valuestr = NULL;
+    int result = LDAP_SUCCESS;
+    char **refs = NULL;
+    LDAPControl **serverctrls = 0;
 
     if (!PyArg_ParseTuple( args, "|iidiii", &msgid, &all, &timeout, &add_ctrls, &add_intermediates, &add_extop ))
         return NULL;
@@ -1033,9 +1036,6 @@ l_ldap_result4( LDAPObject* self, PyObject *args )
     if (msg)
         res_msgid = ldap_msgid(msg);
 
-    int result = LDAP_SUCCESS;
-    char **refs = NULL;
-    LDAPControl **serverctrls = 0;
     if (res_type == LDAP_RES_SEARCH_ENTRY) {
         /* LDAPmessage_to_python will parse entries and read the controls for each entry */
     } else if (res_type == LDAP_RES_SEARCH_REFERENCE) {

--- a/Modules/constants.c
+++ b/Modules/constants.c
@@ -60,11 +60,10 @@ LDAPerror( LDAP *l, char *msg )
     PyObject *info;
     PyObject *str;
     PyObject *pyerrno;
+    char *matched, *error;
 
     /* at first save errno for later use before it gets overwritten by another call */
     myerrno = errno;
-
-    char *matched, *error;
 
     opt_errnum = ldap_get_option(l, LDAP_OPT_ERROR_NUMBER, &errnum);
     if (opt_errnum != LDAP_OPT_SUCCESS)

--- a/Modules/ldapmodule.c
+++ b/Modules/ldapmodule.c
@@ -41,10 +41,6 @@ PyObject* init_ldap_module(void)
 {
 	PyObject *m, *d;
 
-	/* Initialize LDAP class */
-	if (PyType_Ready(&LDAP_Type) < 0)
-		return NULL;
-
 	/* Create the module and add the functions */
 #if PY_MAJOR_VERSION >= 3
         static struct PyModuleDef ldap_moduledef = {
@@ -58,6 +54,11 @@ PyObject* init_ldap_module(void)
 #else
 	m = Py_InitModule("_ldap", methods);
 #endif
+        /* Initialize LDAP class */
+        if (PyType_Ready(&LDAP_Type) < 0) {
+		Py_DECREF(m);
+		return NULL;
+	}
 
 	/* Add some symbolic constants to the module */
 	d = PyModule_GetDict(m);

--- a/Modules/message.c
+++ b/Modules/message.c
@@ -92,10 +92,11 @@ LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls, int add_intermedi
 	 ) {
 	     PyObject* valuelist;
 	     PyObject* pyattr;
+	     struct berval **bvals;
+
 	     pyattr = PyUnicode_FromString(attr);
 
-	     struct berval ** bvals =
-	     	ldap_get_values_len( ld, entry, attr );
+	     bvals = ldap_get_values_len( ld, entry, attr );
 
 	     /* Find which list to append to */
 	     if ( PyDict_Contains( attrdict, pyattr ) ) {


### PR DESCRIPTION
In strict ISO C90 mode and on some platforms (e.g. older MSVC), it is
not allowed to declare new variables after a statement. I also find it
good practice to declare first.

Fixes error: ISO C90 forbids mixed declarations and code
[-Werror=declaration-after-statement]

Signed-off-by: Christian Heimes <cheimes@redhat.com>