### PR TITLE
Use SlapdTestCase in t_bind and t_edit

### DIFF
--- a/Tests/t_bind.py
+++ b/Tests/t_bind.py
@@ -10,25 +10,15 @@ else:
     text_type = str
 
 import ldap, unittest
-from slapdtest import SlapdObject
+from slapdtest import SlapdTestCase
 from ldap.ldapobject import LDAPObject
 
-class TestBinds(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        cls.server = SlapdObject()
-        cls.server.start()
-
-        cls.unicode_val = "abc\U0001f498def"
-        cls.unicode_val_bytes = cls.unicode_val.encode('utf-8')
-
-        cls.dn_unicode = "CN=" + cls.unicode_val
-        cls.dn_bytes = cls.dn_unicode.encode('utf-8')
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.server.stop()
+class TestBinds(SlapdTestCase):
+    unicode_val = "abc\U0001f498def"
+    unicode_val_bytes = unicode_val.encode('utf-8')
+    dn_unicode = "CN=" + unicode_val
+    dn_bytes = dn_unicode.encode('utf-8')
 
     def _get_ldapobject(self, bytes_mode=None):
         l = LDAPObject(self.server.ldap_uri, bytes_mode=bytes_mode)


### PR DESCRIPTION
Both test modules used to set up their own server instance. t_edit
didn't clean up properly. Let's use SlapdTestCase test class everywhere.

Signed-off-by: Christian Heimes <cheimes@redhat.com>