### PR TITLE
Skip some TLS tests when libldap used NSS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ env:
         # -Werror: turn all warnings into fatal errors
         # -Werror=declaration-after-statement: strict ISO C90
         - CFLAGS="-std=c90 -Wno-int-in-bool-context -Werror -Werror=declaration-after-statement"
-        # pass CFLAGS and WITH_GCOV to tox tasks
-        - TOX_TESTENV_PASSENV="CFLAGS WITH_GCOV"
+        # pass CFLAGS, CI (for Travis CI) and WITH_GCOV to tox tasks
+        - TOX_TESTENV_PASSENV="CFLAGS CI WITH_GCOV"
 
 install:
   - pip install "pip>=7.1.0"

--- a/Tests/t_ldap_sasl.py
+++ b/Tests/t_ldap_sasl.py
@@ -14,7 +14,7 @@ os.environ['LDAPNOINIT'] = '1'
 
 from ldap.ldapobject import SimpleLDAPObject
 import ldap.sasl
-from slapdtest import SlapdTestCase
+from slapdtest import SlapdTestCase, requires_tls
 
 
 LDIF = """
@@ -75,6 +75,7 @@ class TestSasl(SlapdTestCase):
             "dn:{}".format(self.server.root_dn.lower())
         )
 
+    @requires_tls(skip_nss=True)
     def test_external_tlscert(self):
         ldap_conn = self.ldap_object_class(self.server.ldap_uri)
         ldap_conn.set_option(ldap.OPT_X_TLS_CACERTFILE, self.server.cafile)
@@ -82,12 +83,7 @@ class TestSasl(SlapdTestCase):
         ldap_conn.set_option(ldap.OPT_X_TLS_KEYFILE, self.server.clientkey)
         ldap_conn.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_HARD)
         ldap_conn.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
-        try:
-            ldap_conn.start_tls_s()
-        except ldap.CONNECT_ERROR as e:
-            # TODO: On Fedora 27 OpenLDAP server refuses STARTTLS when test
-            # is executed with other tests,
-            raise unittest.SkipTest("buggy start_tls_s: {}".format(e))
+        ldap_conn.start_tls_s()
 
         auth = ldap.sasl.external()
         ldap_conn.sasl_interactive_bind_s("", auth)


### PR DESCRIPTION
Some TLS tests are broken or flaky when libldap is compiled with NSS as
TLS provider. It currently affects Fedora 27 and older releases.

Fedora issue: https://bugzilla.redhat.com/show_bug.cgi?id=1519167

https://github.com/python-ldap/python-ldap/issues/60

Signed-off-by: Christian Heimes <cheimes@redhat.com>