### PR TITLE
Ship documentation in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,5 @@ recursive-include Build *.cfg*
 recursive-include Lib *.py
 recursive-include Demo *.py
 recursive-include Tests *.py *.ldif
+recursive-include Doc *.rst conf.py spelling_wordlist.txt Makefile
+prune Doc/.build

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,5 @@ recursive-include Build *.cfg*
 recursive-include Lib *.py
 recursive-include Demo *.py
 recursive-include Tests *.py *.ldif
-recursive-include Doc *.rst conf.py spelling_wordlist.txt Makefile
+recursive-include Doc *.rst *.py spelling_wordlist.txt Makefile
 prune Doc/.build


### PR DESCRIPTION
Source distributions (sdist) of python-ldap now contain documentation.
This allows users to build and read docs locally. Also fixes tox test
run in sdist.

Signed-off-by: Christian Heimes <cheimes@redhat.com>