### PR TITLE
Fix memory leak in whoami_s

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -33,6 +33,7 @@ Modules/
 * Fix multiple ref leaks in error-handling code
 * Fix reference leak in result4
 * Fix several compiler warnings
+* Fix memory leak in whoami
 and, thanks to Michael Ströder:
 * removed unused code schema.c
 * moved code from version.c to ldapmodule.c

--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -1227,10 +1227,13 @@ l_ldap_whoami_s( LDAPObject* self, PyObject* args )
     LDAPControl_List_DEL( server_ldcs );
     LDAPControl_List_DEL( client_ldcs );
 
-    if ( ldaperror!=LDAP_SUCCESS )
+    if ( ldaperror!=LDAP_SUCCESS ) {
+        ber_bvfree(bvalue);
         return LDAPerror( self->ldap, "ldap_whoami_s" );
+    }
 
     result = LDAPberval_to_unicode_object(bvalue);
+    ber_bvfree(bvalue);
 
     return result;
 }


### PR DESCRIPTION
l_ldap_whoami_s() did not free the berval struct from ldap_whoami_s().

Closes: https://github.com/python-ldap/python-ldap/issues/80
Signed-off-by: Christian Heimes <cheimes@redhat.com>