### PR TITLE
Fix two memory leaks in encode_assertion_control

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -35,6 +35,7 @@ Modules/
 * Fix several compiler warnings
 * Fix memory leak in whoami
 * Fix internal error handling of LDAPControl_to_List()
+* Fix two memory leaks and release GIL in encode_assertion_control
 and, thanks to Michael Ströder:
 * removed unused code schema.c
 * moved code from version.c to ldapmodule.c


### PR DESCRIPTION
encode_assertion_control was leaking a LDAP* struct and BER data values
on every call. Both data structures are now properly freed and the GIL
is released around ldap_create() and ldap_unbind_s().

Closes: https://github.com/python-ldap/python-ldap/issues/79
Signed-off-by: Christian Heimes <cheimes@redhat.com>