### PR TITLE
Run tests without SASL and TLS bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,14 @@ matrix:
       env:
         - TOXENV=py36
         - WITH_GCOV=1
+    - python: 2.7
+      env:
+        - TOXENV=py2-nosasltls
+        - WITH_GCOV=1
+    - python: 3.6
+      env:
+        - TOXENV=py3-nosasltls
+        - WITH_GCOV=1
     - python: 3.6
       env: TOXENV=doc
 

--- a/Doc/contributing.rst
+++ b/Doc/contributing.rst
@@ -146,6 +146,8 @@ for checking things independent of the Python version:
 * ``doc`` checks syntax and spelling of the documentation
 * ``coverage-report`` generates a test coverage report for Python code.
   It must be used last, e.g. ``tox -e py27,py36,coverage-report``.
+* ``py2-nosasltls`` and ``py3-nosasltls`` check functionality without
+  SASL and TLS bindings compiled in.
 
 
 When your change is ready, commit to Git, and submit a pull request on GitHub.

--- a/Lib/slapdtest/__init__.py
+++ b/Lib/slapdtest/__init__.py
@@ -8,4 +8,4 @@ See https://www.python-ldap.org/ for details.
 __version__ = '3.0.0b1'
 
 from slapdtest._slapdtest import SlapdObject, SlapdTestCase, SysLogHandler
-from slapdtest._slapdtest import skip_unless_ci, requires_tls
+from slapdtest._slapdtest import skip_unless_ci, requires_sasl, requires_tls

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -212,6 +212,21 @@ class TestLdapCExtension(SlapdTestCase):
         self.assertNotNone(_ldap.URL_ERR_BADSCOPE)
         self.assertNotNone(_ldap.URL_ERR_MEM)
 
+    def test_test_flags(self):
+        # test flag, see slapdtest and tox.ini
+        disabled = os.environ.get('CI_DISABLED')
+        if not disabled:
+            self.skipTest("No CI_DISABLED env var")
+        disabled = set(disabled.split(':'))
+        if 'TLS' in disabled:
+            self.assertFalse(_ldap.TLS_AVAIL)
+        else:
+            self.assertFalse(_ldap.TLS_AVAIL)
+        if 'SASL' in disabled:
+            self.assertFalse(_ldap.SASL_AVAIL)
+        else:
+            self.assertFalse(_ldap.SASL_AVAIL)
+
     def test_simple_bind(self):
         l = self._open_conn()
 

--- a/Tests/t_ldap_sasl.py
+++ b/Tests/t_ldap_sasl.py
@@ -14,7 +14,7 @@ os.environ['LDAPNOINIT'] = '1'
 
 from ldap.ldapobject import SimpleLDAPObject
 import ldap.sasl
-from slapdtest import SlapdTestCase, requires_tls
+from slapdtest import SlapdTestCase, requires_sasl, requires_tls
 
 
 LDIF = """
@@ -39,6 +39,7 @@ cn: {certuser}
 """
 
 
+@requires_sasl()
 class TestSasl(SlapdTestCase):
     ldap_object_class = SimpleLDAPObject
     # from Tests/certs/client.pem

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -19,7 +19,7 @@ else:
 import os
 import unittest
 import pickle
-from slapdtest import SlapdTestCase
+from slapdtest import SlapdTestCase, requires_sasl
 
 # Switch off processing .ldaprc or ldap.conf before importing _ldap
 os.environ['LDAPNOINIT'] = '1'
@@ -298,6 +298,7 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
         else:
             self.fail("expected INVALID_CREDENTIALS, got %r" % r)
 
+    @requires_sasl()
     def test006_sasl_extenal_bind_s(self):
         l = self.ldap_object_class(self.server.ldapi_uri)
         l.sasl_external_bind_s()
@@ -322,6 +323,7 @@ class Test01_ReconnectLDAPObject(Test00_SimpleLDAPObject):
 
     ldap_object_class = ReconnectLDAPObject
 
+    @requires_sasl()
     def test101_reconnect_sasl_external(self):
         l = self.ldap_object_class(self.server.ldapi_uri)
         l.sasl_external_bind_s()

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,8 @@
 
 [tox]
 # Note: when updating Python versions, also change setup.py and .travis.yml
-envlist = py27,py33,py34,py35,py36,doc,coverage-report
+envlist = py27,py33,py34,py35,py36,{py2,py3}-nosasltls,doc,coverage-report
+minver = 1.8
 
 [testenv]
 deps = coverage
@@ -21,8 +22,29 @@ commands = {envpython} -bb -Werror \
 
 [testenv:py27]
 # No warnings with Python 2.7
+passenv = {[testenv]passenv}
 commands = {envpython} \
     -m coverage run --parallel setup.py test
+
+[testenv:py2-nosasltls]
+basepython = python2
+deps = {[testenv]deps}
+passenv = {[testenv]passenv}
+setenv =
+    CI_DISABLED=TLS:SASL
+# rebuild without SASL and TLS
+commands = {envpython} \
+    -m coverage run --parallel setup.py \
+        clean --all \
+        build_ext -UHAVE_SASL,HAVE_TLS \
+        test
+
+[testenv:py3-nosasltls]
+basepython = python3
+deps = {[testenv]deps}
+passenv = {[testenv]passenv}
+setenv = {[testenv:py2-nosasltls]setenv}
+commands = {[testenv:py2-nosasltls]commands}
 
 [testenv:coverage-report]
 deps = coverage


### PR DESCRIPTION
Also fixes tests when _ldap extension is compiled without SASL support.

Signed-off-by: Christian Heimes <cheimes@redhat.com>