### PR TITLE
Add the 3.0.0b1 release date to CHANGES

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,5 @@
 ----------------------------------------------------------------
-Released 3.0.0b1 xxxx-xx-xx
+Released 3.0.0b1 2017-12-04
 
 Changes since 2.4.45:
 (this list includes changes from 2.5.x)

--- a/Doc/contributing.rst
+++ b/Doc/contributing.rst
@@ -259,6 +259,7 @@ If you are tasked with releasing python-ldap, remember to:
 * Bump all instances of the version number.
 * Go through all changes since last version, and add them to ``CHANGES``.
 * Run :ref:`additional tests` as appropriate, fix any regressions.
+* Change the release date in ``CHANGES``.
 * Merge all that (using pull requests).
 * Run ``python setup.py sdist``, and smoke-test the resulting package
   (install in a clean virtual environment, import ``ldap``).


### PR DESCRIPTION
Well, 3.0.0b1 is tagged, but – of course I forgot something.
That's why I'm doing a beta.