### PR TITLE
Use uniform shebang in all demos

### DIFF
--- a/Demo/pyasn1/sessiontrack.py
+++ b/Demo/pyasn1/sessiontrack.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 demo_track_ldap_session.py

--- a/Demo/pyasn1/syncrepl.py
+++ b/Demo/pyasn1/syncrepl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
 This script implements a syncrepl consumer which syncs data from an OpenLDAP

--- a/Demo/simplebrowse.py
+++ b/Demo/simplebrowse.py
@@ -1,4 +1,4 @@
-#! python
+#!/usr/bin/env python
 
 #
 # simple LDAP server browsing example


### PR DESCRIPTION
Demo scripts used different style of shebangs. The shebang
"#!/usr/bin/env python" is preferred because it works nicely in virtual
envs.

Signed-off-by: Christian Heimes <cheimes@redhat.com>