### PR TITLE
Use custom ldap.LDAPBytesWarning class

### DIFF
--- a/Doc/bytes_mode.rst
+++ b/Doc/bytes_mode.rst
@@ -66,7 +66,9 @@ Unspecified: relaxed mode with warnings
 
     Text values returned from python-ldap are always ``unicode``.
     Text values supplied to python-ldap should be ``unicode``;
-    warnings are emitted when they are not.
+    warnings of type :class:`ldap.LDAPBytesWarning` are emitted when they
+    are not. :class:`ldap.LDAPBytesWarning` is a subclass of
+    :class:`BytesWarning`.
 
 Backwards-compatible behavior is not scheduled for removal until Python 2
 itself reaches end of life.
@@ -103,3 +105,18 @@ Note that only the result's *values* are of the ``bytes`` type:
             'sn': [b'Barrois'],
         }),
     ]
+
+
+Filter warning
+--------------
+
+The bytes mode warnings can be filtered out and ignored with a
+simple filter.
+
+.. code-block:: python
+
+   import warnings
+   import ldap
+
+   if hasattr(ldap, 'LDAPBytesWarning'):
+       warnings.simplefilter('ignore', ldap.LDAPBytesWarning)

--- a/Doc/bytes_mode.rst
+++ b/Doc/bytes_mode.rst
@@ -66,9 +66,11 @@ Unspecified: relaxed mode with warnings
 
     Text values returned from python-ldap are always ``unicode``.
     Text values supplied to python-ldap should be ``unicode``;
-    warnings of type :class:`ldap.LDAPBytesWarning` are emitted when they
-    are not. :class:`ldap.LDAPBytesWarning` is a subclass of
-    :class:`BytesWarning`.
+    warnings are emitted when they are not.
+
+    The warnings are of type :class:`~ldap.LDAPBytesWarning`, which
+    is a subclass of :class:`BytesWarning` designed to be easily
+    :ref:`filtered out <filter-bytes-warning>` if needed.
 
 Backwards-compatible behavior is not scheduled for removal until Python 2
 itself reaches end of life.
@@ -107,8 +109,10 @@ Note that only the result's *values* are of the ``bytes`` type:
     ]
 
 
-Filter warning
---------------
+.. _filter-bytes-warning:
+
+Filtering warnings
+------------------
 
 The bytes mode warnings can be filtered out and ignored with a
 simple filter.

--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -564,6 +564,18 @@ The above exceptions are raised when a result code from an underlying API
 call does not indicate success.
 
 
+Warnings
+========
+
+.. py:class:: LDAPBytesWarning
+
+    Raised when bytes/text mismatch in non-strict bytes mode.
+
+    See :ref:`bytes_mode` for details.
+
+    .. versionadded:: 3.0.0
+
+
 .. _ldap-objects:
 
 LDAPObject classes

--- a/Lib/ldap/__init__.py
+++ b/Lib/ldap/__init__.py
@@ -86,7 +86,7 @@ _ldap_module_lock = LDAPLock(desc='Module wide')
 
 from ldap.functions import open,initialize,init,get_option,set_option,escape_str,strf_secs,strp_secs
 
-from ldap.ldapobject import NO_UNIQUE_ENTRY
+from ldap.ldapobject import NO_UNIQUE_ENTRY, LDAPBytesWarning
 
 from ldap.dn import explode_dn,explode_rdn,str2dn,dn2str
 del str2dn

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -14,6 +14,7 @@ __all__ = [
   'LDAPObject',
   'SimpleLDAPObject',
   'ReconnectLDAPObject',
+  'LDAPBytesWarning'
 ]
 
 
@@ -36,6 +37,12 @@ if PY2:
   text_type = unicode
 else:
   text_type = str
+
+
+class LDAPBytesWarning(BytesWarning):
+  """python-ldap bytes mode warning
+  """
+
 
 class NO_UNIQUE_ENTRY(ldap.NO_SUCH_OBJECT):
   """
@@ -84,7 +91,7 @@ class SimpleLDAPObject:
         "Under Python 2, python-ldap uses bytes by default. "
         "This will be removed in Python 3 (no bytes for DN/RDN/field names). "
         "Please call initialize(..., bytes_mode=False) explicitly.",
-        BytesWarning,
+        LDAPBytesWarning,
         stacklevel=2,
       )
       bytes_mode = True
@@ -122,7 +129,7 @@ class SimpleLDAPObject:
           warnings.warn(
             "Received non-bytes value %r with default (disabled) bytes mode; please choose an explicit "
             "option for bytes_mode on your LDAP connection" % (value,),
-            BytesWarning,
+            LDAPBytesWarning,
             stacklevel=6,
           )
           return value.encode('utf-8')


### PR DESCRIPTION
Under Python 2, python-ldap now uses custom ldap.LDAPBytesWarning
instead of BytesWarning to emit warnings in default bytes mode.

Closes: https://github.com/python-ldap/python-ldap/issues/99
Signed-off-by: Christian Heimes <cheimes@redhat.com>