### PR TITLE
Change memory handling in attrs_from_List()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ matrix:
       env:
         - TOXENV=py36
         - WITH_GCOV=1
+    - python: 3.7-dev
+      env:
+        - TOXENV=py37
+        - WITH_GCOV=1
     - python: 2.7
       env:
         - TOXENV=py2-nosasltls
@@ -44,6 +48,10 @@ matrix:
         - WITH_GCOV=1
     - python: 3.6
       env: TOXENV=doc
+  allow_failures:
+     - env:
+        - TOXENV=py37
+        - WITH_GCOV=1
 
 env:
     global:


### PR DESCRIPTION
attrs_from_List() no longer uses internal buffers of bytes/str PyObject*
to maintain memory. Instead it creates its own copies, which are then
passed to ldap_search_ext() and then cleaned up.

The modification is required for Python 3.7. PyUnicode_AsUTF8() returns
const char* but ldap_search_ext() does not use const.

Closes: https://github.com/python-ldap/python-ldap/issues/105
Signed-off-by: Christian Heimes <cheimes@redhat.com>