### PR TITLE
Make valgrind check more useful

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,9 +63,17 @@ $(PYTHON_SUPP):
 	exit 1;
 
 valgrind: build $(PYTHON_SUPP)
-	valgrind --leak-check=full \
+	valgrind \
+	    --leak-check=full \
+	    --track-fds=yes \
 	    --suppressions=$(PYTHON_SUPP) \
 	    --suppressions=Misc/python-ldap.supp \
 	    --gen-suppressions=all \
 	    --log-file=build/valgrind.log \
 	    $(PYTHON) setup.py test
+
+	@grep -A7 "blocks are definitely lost" build/valgrind.log; \
+	if [ $$? == 0 ]; then \
+	    echo "Found definitive leak, see build/valgrind.log"; \
+	    exit 1; \
+	fi

--- a/Misc/python-ldap.supp
+++ b/Misc/python-ldap.supp
@@ -28,6 +28,16 @@
 }
 
 {
+   NSS backend leaks one string during first initialization
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:PL_strdup
+   fun:tlsm_init
+   ...
+}
+
+{
    Ignore possible leaks in exception initialization
    Memcheck:Leak
    match-leak-kinds: possible


### PR DESCRIPTION
* make valgrind now fails when valgrind detects a definitive memory leak
* suppress a known memory leak in OpenLDAP's NSS module
* suppress some extra noise from CPython

Signed-off-by: Christian Heimes <cheimes@redhat.com>