### PR TITLE
Remove workaround for OpenLDAP NSS issue

### DIFF
--- a/Doc/installing.rst
+++ b/Doc/installing.rst
@@ -132,6 +132,29 @@ on the local system when building python-ldap:
 .. _Cyrus SASL: https://www.cyrusimap.org/sasl/
 
 
+Debian
+------
+
+Packages for building and testing::
+
+    apt-get install build-essential python3-dev python2.7-dev libldap2-dev \
+        libsasl2-dev slapd ldap-utils python-tox valgrind
+
+
+Fedora
+------
+
+Packages for building and testing::
+
+    dnf install "@C Development Tools and Libraries" openldap-devel \
+        python2-devel python3-devel python3-tox valgrind clang-analyzer
+
+.. note::
+
+   ``openldap-2.4.45-2`` (Fedora 26), ``openldap-2.4.45-4`` (Fedora 27) or
+   newer are required.
+
+
 setup.cfg
 =========
 

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -76,21 +76,13 @@ def skip_unless_ci(reason, feature=None):
         return identity
 
 
-def requires_tls(skip_nss=False):
+def requires_tls():
     """Decorator for TLS tests
 
     Tests are not skipped on CI (e.g. Travis CI)
-    
-    :param skip_nss: Skip test when libldap is compiled with NSS as TLS lib
     """
     if not ldap.TLS_AVAIL:
         return skip_unless_ci("test needs ldap.TLS_AVAIL", feature='TLS')
-    elif skip_nss and ldap.get_option(ldap.OPT_X_TLS_PACKAGE) == 'MozNSS':
-        return skip_unless_ci(
-            "Test doesn't work correctly with Mozilla NSS, see "
-            "https://bugzilla.redhat.com/show_bug.cgi?id=1519167",
-            feature="NSS"
-        )
     else:
         return identity
 

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -817,7 +817,7 @@ class TestLdapCExtension(SlapdTestCase):
                 l.sasl_interactive_bind_s, 'who', 'SASLObject', post=(1,))
         self.assertInvalidControls(l.unbind_ext)
 
-    @requires_tls(skip_nss=True)
+    @requires_tls()
     def test_tls_ext(self):
         l = self._open_conn(bind=False)
         # StartTLS needs LDAPv3
@@ -827,7 +827,7 @@ class TestLdapCExtension(SlapdTestCase):
         l.set_option(_ldap.OPT_X_TLS_NEWCTX, 0)
         l.start_tls_s()
 
-    @requires_tls(skip_nss=False)
+    @requires_tls()
     def test_tls_ext_noca(self):
         l = self._open_conn(bind=False)
         l.set_option(_ldap.OPT_PROTOCOL_VERSION, _ldap.VERSION3)
@@ -844,7 +844,7 @@ class TestLdapCExtension(SlapdTestCase):
         if not any(s in msg.lower() for s in candidates):
             self.fail(msg)
 
-    @requires_tls(skip_nss=True)
+    @requires_tls()
     def test_tls_ext_clientcert(self):
         l = self._open_conn(bind=False)
         l.set_option(_ldap.OPT_PROTOCOL_VERSION, _ldap.VERSION3)
@@ -855,7 +855,7 @@ class TestLdapCExtension(SlapdTestCase):
         l.set_option(_ldap.OPT_X_TLS_NEWCTX, 0)
         l.start_tls_s()
 
-    @requires_tls(skip_nss=False)
+    @requires_tls()
     def test_tls_packages(self):
         # libldap has tls_g.c, tls_m.c, and tls_o.c with ldap_int_tls_impl
         package = _ldap.get_option(_ldap.OPT_X_TLS_PACKAGE)

--- a/Tests/t_ldap_sasl.py
+++ b/Tests/t_ldap_sasl.py
@@ -76,7 +76,7 @@ class TestSasl(SlapdTestCase):
             "dn:{}".format(self.server.root_dn.lower())
         )
 
-    @requires_tls(skip_nss=True)
+    @requires_tls()
     def test_external_tlscert(self):
         ldap_conn = self.ldap_object_class(self.server.ldap_uri)
         ldap_conn.set_option(ldap.OPT_X_TLS_CACERTFILE, self.server.cafile)


### PR DESCRIPTION
The NSS issue has been fixed in Fedora update openldap-2.4.45-2.fc26 and
openldap-2.4.45-4.fc27. Fedora users can now execute all tests.

Includes documentation for build requirements and minimum versions on
Fedora.

See: https://bugzilla.redhat.com/show_bug.cgi?id=1520990
Closes: https://github.com/python-ldap/python-ldap/issues/60
Closes: https://github.com/python-ldap/python-ldap/issues/51
Signed-off-by: Christian Heimes <cheimes@redhat.com>