### PR TITLE
Prefer literals throughout project

### DIFF
--- a/Demo/pyasn1/syncrepl.py
+++ b/Demo/pyasn1/syncrepl.py
@@ -45,9 +45,9 @@ class SyncReplClient(ReconnectLDAPObject, SyncreplConsumer):
         if db_path:
             self.__data = shelve.open(db_path, 'c')
         else:
-            self.__data = dict()
+            self.__data = {}
         # We need this for later internal use
-        self.__presentUUIDs = dict()
+        self.__presentUUIDs = {}
 
     def close_db(self):
         # Close the data store properly to avoid corruption
@@ -64,7 +64,7 @@ class SyncReplClient(ReconnectLDAPObject, SyncreplConsumer):
         logger.debug('dn=%r attributes=%r uuid=%r', dn, attributes, uuid)
         # First we determine the type of change we have here
         # (and store away the previous data for later if needed)
-        previous_attributes = dict()
+        previous_attributes = {}
         if uuid in self.__data:
             change_type = 'modify'
             previous_attributes = self.__data[uuid]

--- a/Lib/ldap/asyncsearch.py
+++ b/Lib/ldap/asyncsearch.py
@@ -8,16 +8,16 @@ import ldap
 
 from ldap import __version__
 
-SEARCH_RESULT_TYPES = set([
+SEARCH_RESULT_TYPES = {
   ldap.RES_SEARCH_ENTRY,
   ldap.RES_SEARCH_RESULT,
   ldap.RES_SEARCH_REFERENCE,
-])
+}
 
-ENTRY_RESULT_TYPES = set([
+ENTRY_RESULT_TYPES = {
   ldap.RES_SEARCH_ENTRY,
   ldap.RES_SEARCH_RESULT,
-])
+}
 
 
 class WrongResultType(Exception):
@@ -207,7 +207,7 @@ class IndexedDict(Dict):
 
   def __init__(self,l,indexed_attrs=None):
     Dict.__init__(self,l)
-    self.indexed_attrs = indexed_attrs or tuple()
+    self.indexed_attrs = indexed_attrs or ()
     self.index = {}.fromkeys(self.indexed_attrs,{})
 
   def _processSingleResult(self,resultType,resultItem):

--- a/Lib/ldap/controls/deref.py
+++ b/Lib/ldap/controls/deref.py
@@ -107,10 +107,10 @@ class DereferenceControl(LDAPControl):
     self.derefRes = {}
     for deref_res in decodedValue:
       deref_attr,deref_val,deref_vals = deref_res[0],deref_res[1],deref_res[2]
-      partial_attrs_dict = dict([
-        (str(tv[0]),map(str,tv[1]))
+      partial_attrs_dict = {
+        str(tv[0]): map(str,tv[1])
         for tv in deref_vals or []
-      ])
+      }
       try:
         self.derefRes[str(deref_attr)].append((str(deref_val),partial_attrs_dict))
       except KeyError:

--- a/Lib/ldap/controls/psearch.py
+++ b/Lib/ldap/controls/psearch.py
@@ -32,7 +32,7 @@ CHANGE_TYPES_INT = {
   'modify':4,
   'modDN':8,
 }
-CHANGE_TYPES_STR = dict([(v,k) for k,v in CHANGE_TYPES_INT.items()])
+CHANGE_TYPES_STR = {v: k for k,v in CHANGE_TYPES_INT.items()}
 
 
 class PersistentSearchControl(RequestControl):

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -227,10 +227,10 @@ class SimpleLDAPObject:
       return result_value
     if hasattr(result_value, 'items'):
       # It's a attribute_name: [values] dict
-      return dict(
-        (self._maybe_rebytesify_text(key), value)
+      return {
+        self._maybe_rebytesify_text(key): value
         for (key, value) in result_value.items()
-      )
+      }
     elif isinstance(result_value, bytes):
       return result_value
     else:
@@ -991,13 +991,13 @@ class ReconnectLDAPObject(SimpleLDAPObject):
   application.
   """
 
-  __transient_attrs__ = set([
+  __transient_attrs__ = {
     '_l',
     '_ldap_object_lock',
     '_trace_file',
     '_reconnect_lock',
     '_last_bind',
-  ])
+  }
 
   def __init__(
     self,uri,
@@ -1025,11 +1025,11 @@ class ReconnectLDAPObject(SimpleLDAPObject):
 
   def __getstate__(self):
     """return data representation for pickled object"""
-    state = dict([
-        (k,v)
+    state = {
+        k: v
         for k,v in self.__dict__.items()
         if k not in self.__transient_attrs__
-    ])
+    }
     state['_last_bind'] = self._last_bind[0].__name__, self._last_bind[1], self._last_bind[2]
     return state
 

--- a/Lib/ldap/schema/models.py
+++ b/Lib/ldap/schema/models.py
@@ -11,7 +11,7 @@ from ldap.compat import IterableUserDict
 
 from ldap.schema.tokenizer import split_tokens,extract_tokens
 
-NOT_HUMAN_READABLE_LDAP_SYNTAXES = set([
+NOT_HUMAN_READABLE_LDAP_SYNTAXES = {
   '1.3.6.1.4.1.1466.115.121.1.4',  # Audio
   '1.3.6.1.4.1.1466.115.121.1.5',  # Binary
   '1.3.6.1.4.1.1466.115.121.1.8',  # Certificate
@@ -21,7 +21,7 @@ NOT_HUMAN_READABLE_LDAP_SYNTAXES = set([
   '1.3.6.1.4.1.1466.115.121.1.28', # JPEG
   '1.3.6.1.4.1.1466.115.121.1.40', # Octet String
   '1.3.6.1.4.1.1466.115.121.1.49', # Supported Algorithm
-])
+}
 
 
 class SchemaElement:

--- a/Lib/ldap/syncrepl.py
+++ b/Lib/ldap/syncrepl.py
@@ -323,7 +323,7 @@ class SyncInfoMessage:
                     self.newcookie = str(comp)
                     return
 
-                val = dict()
+                val = {}
 
                 cookie = comp.getComponentByName('cookie')
                 if cookie.hasValue():

--- a/Lib/ldif.py
+++ b/Lib/ldif.py
@@ -69,7 +69,7 @@ def list_dict(l):
   """
   return a dictionary with all items of l being the keys of the dictionary
   """
-  return dict([(i,None) for i in l])
+  return {i: None for i in l}
 
 
 class LDIFWriter:

--- a/Tests/t_ldap_syncrepl.py
+++ b/Tests/t_ldap_syncrepl.py
@@ -247,7 +247,7 @@ class SyncreplClient(SimpleLDAPObject, SyncreplConsumer):
             self.present.extend(uuids)
 
         elif (uuids is None) and (refreshDeletes is False):
-            deleted_uuids = list()
+            deleted_uuids = []
             for uuid in self.uuid_dn.keys():
                 if uuid not in self.present:
                     deleted_uuids.append(uuid)

--- a/setup.py
+++ b/setup.py
@@ -71,18 +71,18 @@ name = 'python-ldap'
 # setup() in a fashion that doesn't break compatibility  to
 # distutils. This still allows 'normal' builds where either
 # Python > 2.3.5 or setuptools (or both ;o) are not available.
-kwargs = dict()
+kwargs = {}
 if has_setuptools:
-  kwargs = dict(
-    include_package_data = True,
-    install_requires = [
+  kwargs = {
+    'include_package_data': True,
+    'install_requires': [
         'setuptools',
         'pyasn1 >= 0.3.7',
         'pyasn1_modules >= 0.1.5',
     ],
-    zip_safe = False,
-    python_requires = '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
-  )
+    'zip_safe': False,
+    'python_requires': '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
+  }
 
 setup(
   #-- Package description


### PR DESCRIPTION
- Use a dict literal instead of calling `dict()`.
- Use a list literal instead of calling `list()`.
- Use a set literal instead of calling `set()`.
- Use a tuple literal instead of calling `tuple()`.
- Use dict comprehension

These syntax expressions are available by all supported Python versions. Literals are always faster than calling the constructor. More idiomatic with wider Python community.