### PR TITLE
Run clean --all in all tox targets

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,9 @@ passenv = WITH_GCOV
 commands = {envpython} -bb -Werror \
     "-Wignore:the imp module is deprecated:DeprecationWarning" \
     "-Wignore:the imp module is deprecated:PendingDeprecationWarning" \
-    -m coverage run --parallel setup.py test
+    -m coverage run --parallel setup.py \
+        clean --all \
+        test
 
 [testenv:py27]
 # No warnings with Python 2.7


### PR DESCRIPTION
The second full tox run fails because 'py27' target is picking up C
object files from 'py2-nosasltls'. Each target needs to clean up and
start from scratch.

Signed-off-by: Christian Heimes <cheimes@redhat.com>