### PR TITLE
Run Travis tests with PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ matrix:
       env:
         - TOXENV=py36
         - WITH_GCOV=1
+    - python: pypy
+      env:
+        - TOXENV=pypy
     - python: 3.7-dev
       env:
         - TOXENV=py37
@@ -52,6 +55,8 @@ matrix:
      - env:
         - TOXENV=py37
         - WITH_GCOV=1
+     - env:
+        - TOXENV=pypy
 
 env:
     global:

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,17 @@ passenv = {[testenv]passenv}
 setenv = {[testenv:py2-nosasltls]setenv}
 commands = {[testenv:py2-nosasltls]commands}
 
+[testenv:pypy]
+# PyPy doesn't have working setup.py test
+deps = pytest
+commands = {envpython} -m pytest
+
+[testenv:pypy35]
+# PyPy-5.9.0
+basepython = pypy3.5
+deps = {[testenv:pypy]deps}
+commands = {[testenv:pypy]commands}
+
 [testenv:coverage-report]
 deps = coverage
 skip_install = true


### PR DESCRIPTION
To my surprose, python-ldap works just fine with PyPy2. For Python 3,
PyPy-5.9 (Python 3.5) is required. Fedora's and Ubuntu's PyPy 5.5 is
too old (Python 3.3).

Signed-off-by: Christian Heimes <cheimes@redhat.com>