### PR TITLE
Remove long deprecated functions ldap.open() and ldap.init()

### DIFF
--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -66,28 +66,6 @@ This module defines the following functions:
 
       :rfc:`4516` - Lightweight Directory Access Protocol (LDAP): Uniform Resource Locator
 
-.. py:function:: open(host [, port=PORT]) -> LDAPObject object
-
-   Opens a new connection with an LDAP server, and return an LDAP object  (see
-   :ref:`ldap-objects`) used to perform operations on that server.  *host* is a
-   string containing solely the host name. *port* is an integer specifying the
-   port where the LDAP server is  listening (default is 389).
-
-   .. deprecated:: 3.0
-
-      ``ldap.open()`` is deprecated. It will be removed in version 3.1. Use
-      :func:`ldap.initialize()` with a URI like ``'ldap://<hostname>:<port>'``
-      instead.
-
-.. py:function:: init(host [, port=PORT]) -> LDAPObject object
-
-   Alias of :func:`ldap.open()`.
-
-   .. deprecated:: 3.0
-
-      ``ldap.init()`` is deprecated. It will be removed in version 3.1. Use
-      :func:`ldap.initialize()` with a URI like ``'ldap://<hostname>:<port>'``
-      instead.
 
 .. py:function:: get_option(option) -> int|string
 
@@ -98,6 +76,10 @@ This module defines the following functions:
 
    This function sets the value of the global option specified by *option* to
    *invalue*.
+
+.. versionchanged:: 3.1
+
+   The deprecated functions ``ldap.init()`` and ``ldap.open()`` were removed.
 
 
 .. _ldap-constants:

--- a/Lib/ldap/__init__.py
+++ b/Lib/ldap/__init__.py
@@ -84,7 +84,7 @@ class LDAPLock:
 # Create module-wide lock for serializing all calls into underlying LDAP lib
 _ldap_module_lock = LDAPLock(desc='Module wide')
 
-from ldap.functions import open,initialize,init,get_option,set_option,escape_str,strf_secs,strp_secs
+from ldap.functions import initialize,get_option,set_option,escape_str,strf_secs,strp_secs
 
 from ldap.ldapobject import NO_UNIQUE_ENTRY, LDAPBytesWarning
 

--- a/Lib/ldap/functions.py
+++ b/Lib/ldap/functions.py
@@ -85,36 +85,6 @@ def initialize(uri,trace_level=0,trace_file=sys.stdout,trace_stack_limit=None, b
   return LDAPObject(uri,trace_level,trace_file,trace_stack_limit,bytes_mode)
 
 
-def open(host,port=389,trace_level=0,trace_file=sys.stdout,trace_stack_limit=None,bytes_mode=None):
-  """
-  Return LDAPObject instance by opening LDAP connection to
-  specified LDAP host
-
-  Parameters:
-  host
-        LDAP host and port, e.g. localhost
-  port
-        integer specifying the port number to use, e.g. 389
-  trace_level
-        If non-zero a trace output of LDAP calls is generated.
-  trace_file
-        File object where to write the trace output to.
-        Default is to use stdout.
-  bytes_mode
-        Whether to enable "bytes_mode" for backwards compatibility under Py2.
-  """
-  import warnings
-  warnings.warn(
-    'ldap.open() is deprecated. Use ldap.initialize() instead. It will be '
-    'removed in python-ldap 3.1.',
-    category=DeprecationWarning,
-    stacklevel=2,
-  )
-  return initialize('ldap://%s:%d' % (host,port),trace_level,trace_file,trace_stack_limit,bytes_mode)
-
-init = open
-
-
 def get_option(option):
   """
   get_option(name) -> value


### PR DESCRIPTION
The functions have been deprecated since at least the introduction of the file `Lib/ldap/functions.py` in commit e4173acd69254b950dfeb7663e83a8e338f5df18 on 2011-11-23. That has been lots of time for library users to see the warning and update calling code.

With the move to 3.0.0, a new major version, this is an opportune time to drop deprecated, unused functionality.