### PR TITLE
When raising LDAPBytesWarning, walk the stack to determine stacklevel

### DIFF
--- a/Lib/ldap/functions.py
+++ b/Lib/ldap/functions.py
@@ -27,6 +27,9 @@ if __debug__:
   # Tracing is only supported in debugging mode
   import traceback
 
+# See _raise_byteswarning in ldapobject.py
+_LDAP_WARN_SKIP_FRAME = True
+
 
 def _ldap_function_call(lock,func,*args,**kwargs):
   """

--- a/Modules/ldapmodule.c
+++ b/Modules/ldapmodule.c
@@ -73,7 +73,7 @@ PyObject* init_ldap_module(void)
 	LDAPinit_control(d);
 
     /* Marker for LDAPBytesWarning stack walking
-     * see SimpleLDAPObject._bytesify_input in ldapobject.py
+     * See _raise_byteswarning in ldapobject.py
      */
     if (PyModule_AddIntConstant(m, "_LDAP_WARN_SKIP_FRAME", 1) != 0) {
         return NULL;

--- a/Modules/ldapmodule.c
+++ b/Modules/ldapmodule.c
@@ -72,6 +72,13 @@ PyObject* init_ldap_module(void)
 	LDAPinit_functions(d);
 	LDAPinit_control(d);
 
+    /* Marker for LDAPBytesWarning stack walking
+     * see SimpleLDAPObject._bytesify_input in ldapobject.py
+     */
+    if (PyModule_AddIntConstant(m, "_LDAP_WARN_SKIP_FRAME", 1) != 0) {
+        return NULL;
+    }
+
 	/* Check for errors */
 	if (PyErr_Occurred())
 		Py_FatalError("can't initialize module _ldap");


### PR DESCRIPTION
This is a simplification of https://github.com/python-ldap/python-ldap/pull/120 (and https://github.com/python-ldap/python-ldap/pull/109).

Turns out extension functions have `globals()`, and putting the marker in the `_ldap` module as well means we can only walk the stack – no other changes necessary.
BTW I do like removing `_bytesify_inputs`! Let's do that in 3.1.

I did have some trouble in py2 tests, see the `_normalize` inner function.