### PR TITLE
Add pragma: no cover to avoid spurious cov changes

### DIFF
--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -344,7 +344,9 @@ class SlapdObject(object):
         self._log.info('starting slapd: %r', ' '.join(slapd_args))
         self._proc = subprocess.Popen(slapd_args)
         # Waits until the LDAP server socket is open, or slapd crashed
-        while 1:
+        # no cover to avoid spurious coverage changes, see
+        # https://github.com/python-ldap/python-ldap/issues/127
+        while 1:  # pragma: no cover
             if self._proc.poll() is not None:
                 self._stopped()
                 raise RuntimeError("slapd exited before opening port")
@@ -430,7 +432,9 @@ class SlapdObject(object):
             ]
         return authc_args
 
-    def _cli_popen(self, ldapcommand, extra_args=None, ldap_uri=None, stdin_data=None):
+    # no cover to avoid spurious coverage changes
+    def _cli_popen(self, ldapcommand, extra_args=None, ldap_uri=None,
+                   stdin_data=None):  # pragma: no-cover
         args = [
             ldapcommand,
             '-H', ldap_uri or self.ldapi_uri,


### PR DESCRIPTION
"pragma: no cover" was added to two helper functions in slapdtest to
avoid spurious changes in coverage whenever slapd has a hick up.

Closes: https://github.com/python-ldap/python-ldap/issues/127
Signed-off-by: Christian Heimes <cheimes@redhat.com>