### PR TITLE
Add tests and coverage for tracing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,9 @@ matrix:
         - TOXENV=py3-nosasltls
         - WITH_GCOV=1
     - python: 3.6
+      env:
+        - TOXENV=py3-trace
+    - python: 3.6
       env: TOXENV=doc
   allow_failures:
      - env:

--- a/Lib/ldap/__init__.py
+++ b/Lib/ldap/__init__.py
@@ -8,13 +8,20 @@ See https://www.python-ldap.org/ for details.
 
 from ldap.pkginfo import __version__, __author__, __license__
 
+import os
 import sys
 
 if __debug__:
   # Tracing is only supported in debugging mode
+  import atexit
   import traceback
-  _trace_level = 0
-  _trace_file = sys.stderr
+  _trace_level = int(os.environ.get("PYTHON_LDAP_TRACE_LEVEL", 0))
+  _trace_file = os.environ.get("PYTHON_LDAP_TRACE_FILE")
+  if _trace_file is None:
+    _trace_file = sys.stderr
+  else:
+    _trace_file = open(_trace_file, 'a')
+    atexit.register(_trace_file.close)
   _trace_stack_limit = None
 
 import _ldap

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -96,8 +96,8 @@ class SimpleLDAPObject:
     trace_level=0,trace_file=None,trace_stack_limit=5,bytes_mode=None,
     bytes_strictness=None,
   ):
-    self._trace_level = trace_level
-    self._trace_file = trace_file or sys.stdout
+    self._trace_level = trace_level or ldap._trace_level
+    self._trace_file = trace_file or ldap._trace_file
     self._trace_stack_limit = trace_stack_limit
     self._uri = uri
     self._ldap_object_lock = self._ldap_lock('opcall')
@@ -1123,7 +1123,8 @@ class ReconnectLDAPObject(SimpleLDAPObject):
     self._last_bind = getattr(SimpleLDAPObject, self._last_bind[0]), self._last_bind[1], self._last_bind[2]
     self._ldap_object_lock = self._ldap_lock()
     self._reconnect_lock = ldap.LDAPLock(desc='reconnect lock within %s' % (repr(self)))
-    self._trace_file = sys.stdout
+    # XXX cannot pickle file, use default trace file
+    self._trace_file = ldap._trace_file
     self.reconnect(self._uri)
 
   def _store_last_bind(self,method,*args,**kwargs):

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -690,7 +690,7 @@ class Test01_ReconnectLDAPObject(Test00_SimpleLDAPObject):
                 str('_retry_delay'): 60.0,
                 str('_retry_max'): 1,
                 str('_start_tls'): 0,
-                str('_trace_level'): 0,
+                str('_trace_level'): ldap._trace_level,
                 str('_trace_stack_limit'): 5,
                 str('_uri'): self.server.ldap_uri,
                 str('bytes_mode'): l1.bytes_mode,

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # Note: when updating Python versions, also change setup.py and .travis.yml
-envlist = py27,py34,py35,py36,{py2,py3}-nosasltls,doc,coverage-report
+envlist = py27,py34,py35,py36,{py2,py3}-nosasltls,doc,py3-trace,coverage-report
 minver = 1.8
 
 [testenv]
@@ -48,6 +48,15 @@ deps = {[testenv]deps}
 passenv = {[testenv]passenv}
 setenv = {[testenv:py2-nosasltls]setenv}
 commands = {[testenv:py2-nosasltls]commands}
+
+[testenv:py3-trace]
+basepython = python3
+deps = {[testenv]deps}
+passenv = {[testenv]passenv}
+setenv =
+    PYTHON_LDAP_TRACE_LEVEL=9
+    PYTHON_LDAP_TRACE_FILE={envtmpdir}/trace.log
+commands = {[testenv]commands}
 
 [testenv:pypy]
 # PyPy doesn't have working setup.py test


### PR DESCRIPTION
python-ldap can trace LDAP calls, but it was not possible to use the
feature without changing code manually. Tracing can now be enabled with
the env var PYTHON_LDAP_TRACE_LEVEL and redirected to a file with
PYTHON_LDAP_TRACE_FILE.

Signed-off-by: Christian Heimes <cheimes@redhat.com>