### PR TITLE
Remove override of UserDict.get() to avoid reimplementation

### DIFF
--- a/Lib/ldap/cidict.py
+++ b/Lib/ldap/cidict.py
@@ -44,12 +44,6 @@ class cidict(IterableUserDict):
   def __contains__(self,key):
     return IterableUserDict.__contains__(self, key.lower())
 
-  def get(self,key,failobj=None):
-    try:
-      return self[key]
-    except KeyError:
-      return failobj
-
   def keys(self):
     return self._keys.values()
 

--- a/Lib/ldap/schema/models.py
+++ b/Lib/ldap/schema/models.py
@@ -679,12 +679,6 @@ class Entry(IterableUserDict):
     k = self._at2key(nameoroid)
     return k in self.data
 
-  def get(self,nameoroid,failobj):
-    try:
-      return self[nameoroid]
-    except KeyError:
-      return failobj
-
   def keys(self):
     return self._keytuple2attrtype.values()
 


### PR DESCRIPTION
Reimplements the parent class implementation. Can simplify classes by removing it.