### PR TITLE
Make testing on non-Linux platforms easier

### DIFF
--- a/Lib/ldap/compat.py
+++ b/Lib/ldap/compat.py
@@ -1,6 +1,7 @@
 """Compatibility wrappers for Py2/Py3."""
 
 import sys
+import os
 
 if sys.version_info[0] < 3:
     from UserDict import UserDict, IterableUserDict
@@ -41,3 +42,72 @@ else:
         """
         # In Python 3, all exception info is contained in one object.
         raise exc_value
+
+try:
+    from shutil import which
+except ImportError:
+    # shutil.which() from Python 3.6
+    # "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+    # 2011, 2012, 2013, 2014, 2015, 2016, 2017 Python Software Foundation;
+    # All Rights Reserved"
+    def which(cmd, mode=os.F_OK | os.X_OK, path=None):
+        """Given a command, mode, and a PATH string, return the path which
+        conforms to the given mode on the PATH, or None if there is no such
+        file.
+
+        `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
+        of os.environ.get("PATH"), or can be overridden with a custom search
+        path.
+
+        """
+        # Check that a given file can be accessed with the correct mode.
+        # Additionally check that `file` is not a directory, as on Windows
+        # directories pass the os.access check.
+        def _access_check(fn, mode):
+            return (os.path.exists(fn) and os.access(fn, mode)
+                    and not os.path.isdir(fn))
+
+        # If we're given a path with a directory part, look it up directly rather
+        # than referring to PATH directories. This includes checking relative to the
+        # current directory, e.g. ./script
+        if os.path.dirname(cmd):
+            if _access_check(cmd, mode):
+                return cmd
+            return None
+
+        if path is None:
+            path = os.environ.get("PATH", os.defpath)
+        if not path:
+            return None
+        path = path.split(os.pathsep)
+
+        if sys.platform == "win32":
+            # The current directory takes precedence on Windows.
+            if not os.curdir in path:
+                path.insert(0, os.curdir)
+
+            # PATHEXT is necessary to check on Windows.
+            pathext = os.environ.get("PATHEXT", "").split(os.pathsep)
+            # See if the given file matches any of the expected path extensions.
+            # This will allow us to short circuit when given "python.exe".
+            # If it does match, only test that one, otherwise we have to try
+            # others.
+            if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
+                files = [cmd]
+            else:
+                files = [cmd + ext for ext in pathext]
+        else:
+            # On other platforms you don't have things like PATHEXT to tell you
+            # what file suffixes are executable, so just pass on cmd as-is.
+            files = [cmd]
+
+        seen = set()
+        for dir in path:
+            normdir = os.path.normcase(dir)
+            if not normdir in seen:
+                seen.add(normdir)
+                for thefile in files:
+                    name = os.path.join(dir, thefile)
+                    if _access_check(name, mode):
+                        return name
+        return None

--- a/Lib/slapdtest/__init__.py
+++ b/Lib/slapdtest/__init__.py
@@ -8,4 +8,5 @@ See https://www.python-ldap.org/ for details.
 __version__ = '3.0.0b2'
 
 from slapdtest._slapdtest import SlapdObject, SlapdTestCase, SysLogHandler
-from slapdtest._slapdtest import skip_unless_ci, requires_sasl, requires_tls
+from slapdtest._slapdtest import requires_ldapi, requires_sasl, requires_tls
+from slapdtest._slapdtest import skip_unless_ci

--- a/Tests/t_ldap_sasl.py
+++ b/Tests/t_ldap_sasl.py
@@ -5,7 +5,6 @@ Automatic tests for python-ldap's module ldap.sasl
 See https://www.python-ldap.org/ for details.
 """
 import os
-import pwd
 import socket
 import unittest
 

--- a/Tests/t_ldap_sasl.py
+++ b/Tests/t_ldap_sasl.py
@@ -14,7 +14,8 @@ os.environ['LDAPNOINIT'] = '1'
 
 from ldap.ldapobject import SimpleLDAPObject
 import ldap.sasl
-from slapdtest import SlapdTestCase, requires_sasl, requires_tls
+from slapdtest import SlapdTestCase
+from slapdtest import requires_ldapi, requires_sasl, requires_tls
 
 
 LDIF = """
@@ -60,7 +61,7 @@ class TestSasl(SlapdTestCase):
         )
         cls.server.ldapadd(ldif)
 
-    @unittest.skipUnless(hasattr(socket, 'AF_UNIX'), "needs Unix socket")
+    @requires_ldapi()
     def test_external_ldapi(self):
         # EXTERNAL authentication with LDAPI (AF_UNIX)
         ldap_conn = self.ldap_object_class(self.server.ldapi_uri)

--- a/Tests/t_ldap_schema_subentry.py
+++ b/Tests/t_ldap_schema_subentry.py
@@ -16,7 +16,7 @@ import ldif
 from ldap.ldapobject import SimpleLDAPObject
 import ldap.schema
 from ldap.schema.models import ObjectClass
-from slapdtest import SlapdTestCase
+from slapdtest import SlapdTestCase, requires_ldapi
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
@@ -88,6 +88,7 @@ class TestSubschemaUrlfetchSlapd(SlapdTestCase):
         dn, schema = ldap.schema.urlfetch(self.server.ldap_uri)
         self.assertSlapdSchema(dn, schema)
 
+    @requires_ldapi()
     def test_urlfetch_ldapi(self):
         dn, schema = ldap.schema.urlfetch(self.server.ldapi_uri)
         self.assertSlapdSchema(dn, schema)

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -22,8 +22,8 @@ import os
 import unittest
 import warnings
 import pickle
-import warnings
-from slapdtest import SlapdTestCase, requires_sasl, requires_tls
+from slapdtest import SlapdTestCase
+from slapdtest import requires_ldapi, requires_sasl, requires_tls
 
 # Switch off processing .ldaprc or ldap.conf before importing _ldap
 os.environ['LDAPNOINIT'] = '1'
@@ -303,6 +303,7 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
             self.fail("expected INVALID_CREDENTIALS, got %r" % r)
 
     @requires_sasl()
+    @requires_ldapi()
     def test006_sasl_extenal_bind_s(self):
         l = self.ldap_object_class(self.server.ldapi_uri)
         l.sasl_external_bind_s()
@@ -441,6 +442,7 @@ class Test01_ReconnectLDAPObject(Test00_SimpleLDAPObject):
     ldap_object_class = ReconnectLDAPObject
 
     @requires_sasl()
+    @requires_ldapi()
     def test101_reconnect_sasl_external(self):
         l = self.ldap_object_class(self.server.ldapi_uri)
         l.sasl_external_bind_s()
@@ -450,7 +452,7 @@ class Test01_ReconnectLDAPObject(Test00_SimpleLDAPObject):
         self.assertEqual(l.whoami_s(), authz_id)
 
     def test102_reconnect_simple_bind(self):
-        l = self.ldap_object_class(self.server.ldapi_uri)
+        l = self.ldap_object_class(self.server.ldap_uri)
         bind_dn = 'cn=user1,'+self.server.suffix
         l.simple_bind_s(bind_dn, 'user1_pw')
         self.assertEqual(l.whoami_s(), 'dn:'+bind_dn)
@@ -458,7 +460,7 @@ class Test01_ReconnectLDAPObject(Test00_SimpleLDAPObject):
         self.assertEqual(l.whoami_s(), 'dn:'+bind_dn)
 
     def test103_reconnect_get_state(self):
-        l1 = self.ldap_object_class(self.server.ldapi_uri)
+        l1 = self.ldap_object_class(self.server.ldap_uri)
         bind_dn = 'cn=user1,'+self.server.suffix
         l1.simple_bind_s(bind_dn, 'user1_pw')
         self.assertEqual(l1.whoami_s(), 'dn:'+bind_dn)
@@ -477,7 +479,7 @@ class Test01_ReconnectLDAPObject(Test00_SimpleLDAPObject):
                 str('_start_tls'): 0,
                 str('_trace_level'): 0,
                 str('_trace_stack_limit'): 5,
-                str('_uri'): self.server.ldapi_uri,
+                str('_uri'): self.server.ldap_uri,
                 str('bytes_mode'): l1.bytes_mode,
                 str('bytes_mode_hardfail'): l1.bytes_mode_hardfail,
                 str('timeout'): -1,
@@ -485,7 +487,7 @@ class Test01_ReconnectLDAPObject(Test00_SimpleLDAPObject):
         )
 
     def test104_reconnect_restore(self):
-        l1 = self.ldap_object_class(self.server.ldapi_uri)
+        l1 = self.ldap_object_class(self.server.ldap_uri)
         bind_dn = 'cn=user1,'+self.server.suffix
         l1.simple_bind_s(bind_dn, 'user1_pw')
         self.assertEqual(l1.whoami_s(), 'dn:'+bind_dn)

--- a/tox.ini
+++ b/tox.ini
@@ -33,8 +33,8 @@ basepython = python2
 deps = {[testenv]deps}
 passenv = {[testenv]passenv}
 setenv =
-    CI_DISABLED=TLS:SASL
-# rebuild without SASL and TLS
+    CI_DISABLED=LDAPI:SASL:TLS
+# rebuild without SASL and TLS, run without LDAPI
 commands = {envpython} \
     -m coverage run --parallel setup.py \
         clean --all \


### PR DESCRIPTION
A bunch of small chances to the test suite. It should be enough to make it possible to run the test suite under macOS homebrew and Windows (untested).

* Make LDAPI optional
* Drop unused import of pwd module
* Lookup test binaries in PATH