### PR TITLE
Prepare release 3.0.0b3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,30 @@
 ----------------------------------------------------------------
+Released 3.0.0b3 2017-12-20
+
+Changes since 3.0.0b2:
+
+The functions `ldap.open()`, `ldap.init()`, `ldif.CreateLDIF()`
+and `ldif.ParseLDIF()`, which were deprecated for over a decade,
+are scheduled for removal in python-ldap 3.1.
+
+Infrastructure:
+* Require setuptools to build
+* Start running automatic tests on PyPy
+
+Lib/
+* When raising LDAPBytesWarning, give helpful code locations
+* Use modern Python idioms in several places
+* Avoid reimplementing UserDict.get() in cidict and models.Entry
+
+Doc/
+* Use https links
+
+Test/
+* Add reproducer for openldap's NSS shutdown/restart issue
+* Make testing on non-Linux platforms easier
+
+
+----------------------------------------------------------------
 Released 3.0.0b2 2017-12-11
 
 Changes since 3.0.0b1:

--- a/Lib/ldap/pkginfo.py
+++ b/Lib/ldap/pkginfo.py
@@ -2,6 +2,6 @@
 """
 meta attributes for packaging which does not import any dependencies
 """
-__version__ = '3.0.0b2'
+__version__ = '3.0.0b3'
 __author__ = u'python-ldap project'
 __license__ = 'Python style'

--- a/Lib/ldapurl.py
+++ b/Lib/ldapurl.py
@@ -4,7 +4,7 @@ ldapurl - handling of LDAP URLs as described in RFC 4516
 See https://www.python-ldap.org/ for details.
 """
 
-__version__ = '3.0.0b2'
+__version__ = '3.0.0b3'
 
 __all__ = [
   # constants

--- a/Lib/ldif.py
+++ b/Lib/ldif.py
@@ -6,7 +6,7 @@ See https://www.python-ldap.org/ for details.
 
 from __future__ import unicode_literals
 
-__version__ = '3.0.0b2'
+__version__ = '3.0.0b3'
 
 __all__ = [
   # constants

--- a/Lib/slapdtest/__init__.py
+++ b/Lib/slapdtest/__init__.py
@@ -5,7 +5,7 @@ slapdtest - module for spawning test instances of OpenLDAP's slapd server
 See https://www.python-ldap.org/ for details.
 """
 
-__version__ = '3.0.0b2'
+__version__ = '3.0.0b3'
 
 from slapdtest._slapdtest import SlapdObject, SlapdTestCase, SysLogHandler
 from slapdtest._slapdtest import requires_ldapi, requires_sasl, requires_tls


### PR DESCRIPTION
I'd rather release 3.0.0 already, and drop the betas. But, there are two reasons this is not a good time:

* python-ldap.org is down (see mailing list)
* people are taking vacations before the end of year; doing a release now might not be convenient

On the other hand, I want to open the door to 3.1 changes, which have been piling up.
So, I'm thinking about creating a 3.0 branch after 3.0.0b3 is released, and start merging 3.1 changes to master.