### PR TITLE
Prefer iterating dict instead of calling dict.keys()

### DIFF
--- a/Demo/matchedvalues.py
+++ b/Demo/matchedvalues.py
@@ -35,7 +35,7 @@ from ldap.controls import MatchedValuesControl
 def print_result(search_result):
     for n in range(len(search_result)):
         print("dn: %s" % search_result[n][0])
-        for attr in search_result[n][1].keys():
+        for attr in search_result[n][1]:
             for i in range(len(search_result[n][1][attr])):
                 print("%s: %s" % (attr, search_result[n][1][attr][i]))
         print
@@ -61,4 +61,3 @@ print_result(res)
 res = ld.search_ext_s(base, scope, filter, attrlist = ['mail'], serverctrls = [mv])
 print("Matched values control: %s" % control_filter)
 print_result(res)
-

--- a/Demo/pyasn1/syncrepl.py
+++ b/Demo/pyasn1/syncrepl.py
@@ -99,7 +99,7 @@ class SyncReplClient(ReconnectLDAPObject, SyncreplConsumer):
             if refreshDeletes is False:
                 deletedEntries = [
                     uuid
-                    for uuid in self.__data.keys()
+                    for uuid in self.__data
                     if uuid not in self.__presentUUIDs and uuid != 'ldap_cookie'
                 ]
                 self.syncrepl_delete( deletedEntries )

--- a/Lib/ldap/cidict.py
+++ b/Lib/ldap/cidict.py
@@ -35,7 +35,7 @@ class cidict(IterableUserDict):
     del self.data[lower_key]
 
   def update(self,dict):
-    for key in dict.keys():
+    for key in dict:
       self[key] = dict[key]
 
   def has_key(self,key):
@@ -43,6 +43,9 @@ class cidict(IterableUserDict):
 
   def __contains__(self,key):
     return IterableUserDict.__contains__(self, key.lower())
+
+  def __iter__(self):
+    return iter(self.keys())
 
   def keys(self):
     return self._keys.values()

--- a/Lib/ldap/modlist.py
+++ b/Lib/ldap/modlist.py
@@ -13,7 +13,7 @@ def addModlist(entry,ignore_attr_types=None):
   """Build modify list for call of method LDAPObject.add()"""
   ignore_attr_types = set(map(str.lower,ignore_attr_types or []))
   modlist = []
-  for attrtype in entry.keys():
+  for attrtype in entry:
     if attrtype.lower() in ignore_attr_types:
       # This attribute type is ignored
       continue
@@ -50,9 +50,9 @@ def modifyModlist(
   case_ignore_attr_types = set(map(str.lower,case_ignore_attr_types or []))
   modlist = []
   attrtype_lower_map = {}
-  for a in old_entry.keys():
+  for a in old_entry:
     attrtype_lower_map[a.lower()]=a
-  for attrtype in new_entry.keys():
+  for attrtype in new_entry:
     attrtype_lower = attrtype.lower()
     if attrtype_lower in ignore_attr_types:
       # This attribute type is ignored
@@ -89,7 +89,7 @@ def modifyModlist(
   if not ignore_oldexistent:
     # Remove all attributes of old_entry which are not present
     # in new_entry at all
-    for a in attrtype_lower_map.keys():
+    for a in attrtype_lower_map:
       if a in ignore_attr_types:
         # This attribute type is ignored
         continue

--- a/Lib/ldap/schema/models.py
+++ b/Lib/ldap/schema/models.py
@@ -655,7 +655,7 @@ class Entry(IterableUserDict):
       return t
 
   def update(self,dict):
-    for key in dict.keys():
+    for key in dict:
       self[key] = dict[key]
 
   def __contains__(self,nameoroid):
@@ -679,14 +679,14 @@ class Entry(IterableUserDict):
     k = self._at2key(nameoroid)
     return k in self.data
 
+  def __iter__(self):
+    return iter(self.keys())
+
   def keys(self):
     return self._keytuple2attrtype.values()
 
   def items(self):
-    return [
-      (k,self[k])
-      for k in self.keys()
-    ]
+    return [(k,self[k]) for k in self]
 
   def attribute_types(
     self,attr_type_filter=None,raise_keyerror=1

--- a/Lib/ldap/schema/subentry.py
+++ b/Lib/ldap/schema/subentry.py
@@ -16,7 +16,7 @@ for o in list(vars().values()):
     SCHEMA_CLASS_MAPPING[o.schema_attribute] = o
     SCHEMA_ATTR_MAPPING[o] = o.schema_attribute
 
-SCHEMA_ATTRS = SCHEMA_CLASS_MAPPING.keys()
+SCHEMA_ATTRS = list(SCHEMA_CLASS_MAPPING)
 
 
 class SubschemaError(ValueError):
@@ -115,7 +115,7 @@ class SubSchema:
         self.sed[se_class][se_id] = se_instance
 
         if hasattr(se_instance,'names'):
-          for name in ldap.cidict.cidict({}.fromkeys(se_instance.names)).keys():
+          for name in ldap.cidict.cidict({}.fromkeys(se_instance.names)):
             if check_uniqueness and name in self.name2oid[se_class]:
               self.non_unique_names[se_class][se_id] = None
               raise NameNotUnique(attr_value)
@@ -123,7 +123,7 @@ class SubSchema:
               self.name2oid[se_class][name] = se_id
 
     # Turn dict into list maybe more handy for applications
-    self.non_unique_oids = self.non_unique_oids.keys()
+    self.non_unique_oids = list(self.non_unique_oids)
 
     return # subSchema.__init__()
 
@@ -136,7 +136,7 @@ class SubSchema:
     entry = {}
     # Collect the schema elements and store them in
     # entry's attributes
-    for se_class in self.sed.keys():
+    for se_class in self.sed:
       for se in self.sed[se_class].values():
         se_str = str(se)
         try:
@@ -153,7 +153,7 @@ class SubSchema:
     avail_se = self.sed[schema_element_class]
     if schema_element_filters:
       result = []
-      for se_key in avail_se.keys():
+      for se_key in avail_se:
         se = avail_se[se_key]
         for fk,fv in schema_element_filters:
           try:
@@ -162,7 +162,7 @@ class SubSchema:
           except AttributeError:
             pass
     else:
-      result = avail_se.keys()
+      result = list(avail_se)
     return result
 
 
@@ -417,14 +417,14 @@ class SubSchema:
 
     # Remove all mandantory attribute types from
     # optional attribute type list
-    for a in list(r_may.keys()):
+    for a in list(r_may):
       if a in r_must:
         del r_may[a]
 
     # Apply attr_type_filter to results
     if attr_type_filter:
       for l in [r_must,r_may]:
-        for a in list(l.keys()):
+        for a in list(l):
           for afk,afv in attr_type_filter:
             try:
               schema_attr_type = self.sed[AttributeType][a]

--- a/Lib/ldapurl.py
+++ b/Lib/ldapurl.py
@@ -16,7 +16,7 @@ __all__ = [
   'LDAPUrlExtension','LDAPUrlExtensions','LDAPUrl'
 ]
 
-from ldap.compat import UserDict, quote, unquote
+from ldap.compat import IterableUserDict, quote, unquote
 
 LDAP_SCOPE_BASE = 0
 LDAP_SCOPE_ONELEVEL = 1
@@ -130,14 +130,14 @@ class LDAPUrlExtension(object):
     return not self.__eq__(other)
 
 
-class LDAPUrlExtensions(UserDict):
+class LDAPUrlExtensions(IterableUserDict):
   """
   Models a collection of LDAP URL extensions as
   dictionary type
   """
 
   def __init__(self,default=None):
-    UserDict.__init__(self)
+    IterableUserDict.__init__(self)
     for k,v in (default or {}).items():
       self[k]=v
 
@@ -152,10 +152,7 @@ class LDAPUrlExtensions(UserDict):
     self.data[name] = value
 
   def values(self):
-    return [
-      self[k]
-      for k in self.keys()
-    ]
+    return [self[k] for k in self]
 
   def __str__(self):
     return ','.join(map(str,self.values()))
@@ -313,7 +310,7 @@ class LDAPUrl(object):
         Dictionary containing a mapping from class attributes
         to default values
     """
-    for k in defaults.keys():
+    for k in defaults:
       if getattr(self,k) is None:
         setattr(self,k,defaults[k])
 
@@ -429,4 +426,3 @@ class LDAPUrl(object):
           pass
     else:
       del self.__dict__[name]
-

--- a/Lib/ldif.py
+++ b/Lib/ldif.py
@@ -150,7 +150,7 @@ class LDIFWriter:
     entry
         dictionary holding an entry
     """
-    for attr_type in sorted(entry.keys()):
+    for attr_type in sorted(entry):
       for attr_value in entry[attr_type]:
         self._unparseAttrTypeandValue(attr_type,attr_value)
 

--- a/Tests/t_cidict.py
+++ b/Tests/t_cidict.py
@@ -34,6 +34,8 @@ class TestCidict(unittest.TestCase):
         self.assertEqual(cix.get("xyz", None), 987)
         cix_keys = sorted(cix.keys())
         self.assertEqual(cix_keys, ['AbCDeF','xYZ'])
+        cix_keys = sorted(cix)
+        self.assertEqual(cix_keys, ['AbCDeF','xYZ'])
         cix_items = sorted(cix.items())
         self.assertEqual(cix_items, [('AbCDeF',123), ('xYZ',987)])
         del cix["abcdEF"]

--- a/Tests/t_ldap_syncrepl.py
+++ b/Tests/t_ldap_syncrepl.py
@@ -248,7 +248,7 @@ class SyncreplClient(SimpleLDAPObject, SyncreplConsumer):
 
         elif (uuids is None) and (refreshDeletes is False):
             deleted_uuids = []
-            for uuid in self.uuid_dn.keys():
+            for uuid in self.uuid_dn:
                 if uuid not in self.present:
                     deleted_uuids.append(uuid)
 


### PR DESCRIPTION
Calling `dict.keys()` is unnecessary. `iter(dict)` is equivalent to `dict.keys()`. Inspired by Lennart Regebro's talk "Prehistoric Patterns in Python" from PyCon 2017.

https://www.youtube.com/watch?v=V5-JH23Vk0I