### PR TITLE
Deprecate use of .has_key() to follow modern Python

### DIFF
--- a/Lib/ldap/cidict.py
+++ b/Lib/ldap/cidict.py
@@ -5,6 +5,7 @@ names of variable case.
 
 See https://www.python-ldap.org/ for details.
 """
+import warnings
 
 from ldap import __version__
 
@@ -39,6 +40,12 @@ class cidict(IterableUserDict):
       self[key] = dict[key]
 
   def has_key(self,key):
+    warnings.warn(
+      "%s.has_key() is deprecated and will be removed in a future version of "
+      "python-ldap. Use the 'in' operator instead." % self.__class__.__name__,
+      category=DeprecationWarning,
+      stacklevel=2,
+    )
     return key in self
 
   def __contains__(self,key):

--- a/Lib/ldap/schema/models.py
+++ b/Lib/ldap/schema/models.py
@@ -676,6 +676,12 @@ class Entry(IterableUserDict):
     del self._keytuple2attrtype[k]
 
   def has_key(self,nameoroid):
+    warnings.warn(
+      "%s.has_key() is deprecated and will be removed in a future version of "
+      "python-ldap. Use the 'in' operator instead." % self.__class__.__name__,
+      category=DeprecationWarning,
+      stacklevel=2,
+    )
     k = self._at2key(nameoroid)
     return k in self.data
 

--- a/Tests/t_cidict.py
+++ b/Tests/t_cidict.py
@@ -4,12 +4,20 @@ Automatic tests for python-ldap's module ldap.cidict
 
 See https://www.python-ldap.org/ for details.
 """
+from __future__ import unicode_literals
 
-# from Python's standard lib
+import sys
 import unittest
+import warnings
 
 # from python-ldap
 import ldap, ldap.cidict
+
+
+if sys.version_info[0] <= 2:
+    text_type = unicode
+else:
+    text_type = str
 
 
 class TestCidict(unittest.TestCase):
@@ -41,8 +49,29 @@ class TestCidict(unittest.TestCase):
         self.assertEqual("AbCDef" in cix._keys, False)
         self.assertEqual("abcdef" in cix, False)
         self.assertEqual("AbCDef" in cix, False)
-        self.assertEqual(cix.has_key("abcdef"), False)
-        self.assertEqual(cix.has_key("AbCDef"), False)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.resetwarnings()
+            warnings.simplefilter("always")
+            self.assertEqual(cix.has_key("abcdef"), False)
+        self.assertEqual(len(w), 1)
+        msg = w[-1]
+        self.assertIs(msg.category, DeprecationWarning)
+        self.assertEqual(
+            text_type(msg.message),
+            "cidict.has_key() is deprecated and will be removed in a future version of "
+            "python-ldap. Use the 'in' operator instead."
+        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.assertEqual(cix.has_key("AbCDef"), False)
+        self.assertEqual(len(w), 1)
+        msg = w[-1]
+        self.assertIs(msg.category, DeprecationWarning)
+        self.assertEqual(
+            text_type(msg.message),
+            "cidict.has_key() is deprecated and will be removed in a future version of "
+            "python-ldap. Use the 'in' operator instead."
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Using the in operator is preferred and available on all supported
versions of Python.

From https://docs.python.org/3/whatsnew/3.0.html#builtins

> Removed. dict.has_key() – use the in operator instead.