### PR TITLE
Remove support for EOL Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ matrix:
       env:
         - TOXENV=py27
         - WITH_GCOV=1
-    - python: 3.3
-      env:
-        - TOXENV=py33
-        - WITH_GCOV=1
     - python: 3.4
       env:
         - TOXENV=py34

--- a/Doc/installing.rst
+++ b/Doc/installing.rst
@@ -120,7 +120,7 @@ Build prerequisites
 The following software packages are required to be installed
 on the local system when building python-ldap:
 
-- `Python`_ version 2.7, or 3.3 or later including its development files
+- `Python`_ version 2.7, or 3.4 or later including its development files
 - C compiler corresponding to your Python version (on Linux, it is usually ``gcc``)
 - `OpenLDAP`_ client libs version 2.4.11 or later;
   it is not possible and not supported to build with prior versions.

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ from setuptools import setup, Extension
 
 if sys.version_info[0] == 2 and sys.version_info[1] < 7:
     raise RuntimeError('This software requires Python 2.7 or 3.x.')
-if sys.version_info[0] >= 3 and sys.version_info < (3, 3):
-    raise RuntimeError('The C API from Python 3.3+ is required.')
+if sys.version_info[0] >= 3 and sys.version_info < (3, 4):
+    raise RuntimeError('The C API from Python 3.4+ is required.')
 
 if sys.version_info[0] >= 3:
     from configparser import ConfigParser
@@ -91,7 +91,6 @@ setup(
     'Programming Language :: Python :: 2',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
@@ -168,6 +167,6 @@ setup(
     'pyasn1_modules >= 0.1.5',
   ],
   zip_safe=False,
-  python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
+  python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
   test_suite = 'Tests',
 )

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # Note: when updating Python versions, also change setup.py and .travis.yml
-envlist = py27,py33,py34,py35,py36,{py2,py3}-nosasltls,doc,coverage-report
+envlist = py27,py34,py35,py36,{py2,py3}-nosasltls,doc,coverage-report
 minver = 1.8
 
 [testenv]
@@ -13,8 +13,9 @@ deps = coverage
 passenv = WITH_GCOV
 # - Enable BytesWarning 
 # - Turn all warnings into exceptions.
-# - 'ignore:the imp module is deprecated' is required to ignore import of
-#   'imp' in distutils. Python 3.3 and 3.4 use PendingDeprecationWarning.
+# - 'ignore:the imp module is deprecated' is required to ignore import of 'imp'
+#   in distutils. Python < 3.6 use PendingDeprecationWarning; Python >= 3.6 use
+#   DeprecationWarning.
 commands = {envpython} -bb -Werror \
     "-Wignore:the imp module is deprecated:DeprecationWarning" \
     "-Wignore:the imp module is deprecated:PendingDeprecationWarning" \


### PR DESCRIPTION
Python 3.3 is end of life. It is no longer receiving bug fixes including
for security issues. It has been EOL since 2017-09-29. For a library
focused on authentication, supporting environments that are not
receiving security sends the wrong message. For additional details, see:

https://devguide.python.org/#status-of-python-branches

Reduces testing and maintenance resources.
  