### PR TITLE
simple_bind() accept None for who and cred

### DIFF
--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -1018,7 +1018,7 @@ and wait for and return with the server's result, or with
    .. versionchanged:: 3.0
 
       :meth:`~LDAPObject.simple_bind` and :meth:`~LDAPObject.simple_bind_s`
-      now accept `None` for who and cred, too.
+      now accept ``None`` for *who* and *cred*, too.
 
 
 .. py:method:: LDAPObject.search(base, scope [,filterstr='(objectClass=*)' [, attrlist=None [, attrsonly=0]]]) ->int

--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -1000,9 +1000,9 @@ and wait for and return with the server's result, or with
    *serverctrls* and *clientctrls* like described in section :ref:`ldap-controls`.
 
 
-.. py:method:: LDAPObject.simple_bind([who='' [, cred='' [, serverctrls=None [, clientctrls=None]]]]) -> int
+.. py:method:: LDAPObject.simple_bind([who=None [, cred=None [, serverctrls=None [, clientctrls=None]]]]) -> int
 
-.. py:method:: LDAPObject.simple_bind_s([who='' [, cred='' [, serverctrls=None [, clientctrls=None]]]]) -> None
+.. py:method:: LDAPObject.simple_bind_s([who=None [, cred=None [, serverctrls=None [, clientctrls=None]]]]) -> None
 
    After an LDAP object is created, and before any other operations can be
    attempted over the connection, a bind operation must be performed.
@@ -1014,6 +1014,11 @@ and wait for and return with the server's result, or with
    be :py:const:`AUTH_SIMPLE`.
 
    *serverctrls* and *clientctrls* like described in section :ref:`ldap-controls`.
+
+   .. versionchanged:: 3.0
+
+      :meth:`~LDAPObject.simple_bind` and :meth:`~LDAPObject.simple_bind_s`
+      now accept `None` for who and cred, too.
 
 
 .. py:method:: LDAPObject.search(base, scope [,filterstr='(objectClass=*)' [, attrlist=None [, attrsonly=0]]]) ->int

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -406,7 +406,7 @@ class SimpleLDAPObject:
   def add_s(self,dn,modlist):
     return self.add_ext_s(dn,modlist,None,None)
 
-  def simple_bind(self,who='',cred='',serverctrls=None,clientctrls=None):
+  def simple_bind(self,who=None,cred=None,serverctrls=None,clientctrls=None):
     """
     simple_bind([who='' [,cred='']]) -> int
     """
@@ -415,7 +415,7 @@ class SimpleLDAPObject:
         cred = self._bytesify_input('cred', cred)
     return self._ldap_call(self._l.simple_bind,who,cred,RequestControlTuples(serverctrls),RequestControlTuples(clientctrls))
 
-  def simple_bind_s(self,who='',cred='',serverctrls=None,clientctrls=None):
+  def simple_bind_s(self,who=None,cred=None,serverctrls=None,clientctrls=None):
     """
     simple_bind_s([who='' [,cred='']]) -> 4-tuple
     """
@@ -1107,7 +1107,7 @@ class ReconnectLDAPObject(SimpleLDAPObject):
       func(self,*args,**kwargs)
     else:
       # Send explicit anon simple bind request to provoke ldap.SERVER_DOWN in method reconnect()
-      SimpleLDAPObject.simple_bind_s(self,'','')
+      SimpleLDAPObject.simple_bind_s(self, None, None)
 
   def _restore_options(self):
     """Restore all recorded options"""

--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -499,7 +499,7 @@ l_ldap_simple_bind( LDAPObject* self, PyObject* args )
     LDAPControl** client_ldcs = NULL;
     struct berval cred;
 
-    if (!PyArg_ParseTuple( args, "ss#|OO", &who, &cred.bv_val, &cred_len, &serverctrls, &clientctrls )) return NULL;
+    if (!PyArg_ParseTuple( args, "zz#|OO", &who, &cred.bv_val, &cred_len, &serverctrls, &clientctrls )) return NULL;
     cred.bv_len = (ber_len_t) cred_len;
 
     if (not_valid(self)) return NULL;

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -401,6 +401,14 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
             cls.__mro__
         )
 
+    def test_simple_bind_noarg(self):
+        l = self.ldap_object_class(self.server.ldap_uri)
+        l.simple_bind_s()
+        self.assertEqual(l.whoami_s(), u'')
+        l = self.ldap_object_class(self.server.ldap_uri)
+        l.simple_bind_s(None, None)
+        self.assertEqual(l.whoami_s(), u'')
+
     @unittest.skipUnless(PY2, "no bytes_mode under Py3")
     def test_ldapbyteswarning(self):
         self.assertIsSubclass(ldap.LDAPBytesWarning, BytesWarning)


### PR DESCRIPTION
sasl_bind_s() has accepted None for who and cred for a long time. Now
simple_bind() and simple_bind_s() default to and accept None, too.

See: https://github.com/python-ldap/python-ldap/issues/147

Signed-off-by: Christian Heimes <cheimes@redhat.com>