### PR TITLE
Improve valgrind rule for PR_strdup

### DIFF
--- a/Misc/python-ldap.supp
+++ b/Misc/python-ldap.supp
@@ -33,7 +33,8 @@
    match-leak-kinds: definite
    fun:malloc
    fun:PL_strdup
-   fun:tlsm_init
+   ...
+   fun:ldap_set_option
    ...
 }
 


### PR DESCRIPTION
libldap's NSS engine has one known memory leak. One block of memory is
leaked one time only. The existing rule only matches when all debug
symbols are installed. The new rule should work without debug symbols.

Closes: https://github.com/python-ldap/python-ldap/issues/156
Signed-off-by: Christian Heimes <cheimes@redhat.com>