### PR TITLE
Set LDAPNOINIT and test TLS defaults

### DIFF
--- a/Tests/t_bind.py
+++ b/Tests/t_bind.py
@@ -9,9 +9,15 @@ else:
     PY2 = False
     text_type = str
 
-import ldap, unittest
-from slapdtest import SlapdTestCase
+import os
+import unittest
+
+# Switch off processing .ldaprc or ldap.conf before importing _ldap
+os.environ['LDAPNOINIT'] = '1'
+
+import ldap
 from ldap.ldapobject import LDAPObject
+from slapdtest import SlapdTestCase
 
 
 class TestBinds(SlapdTestCase):

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -827,9 +827,27 @@ class TestLdapCExtension(SlapdTestCase):
         l.start_tls_s()
 
     @requires_tls()
+    def test_tls_require_cert(self):
+        # libldap defaults to secure cert validation
+        # see libraries/libldap/init.c
+        #     gopts->ldo_tls_require_cert = LDAP_OPT_X_TLS_DEMAND;
+
+        self.assertEqual(
+            _ldap.get_option(_ldap.OPT_X_TLS_REQUIRE_CERT),
+            _ldap.OPT_X_TLS_DEMAND
+        )
+        l = self._open_conn(bind=False)
+        self.assertEqual(
+            l.get_option(_ldap.OPT_X_TLS_REQUIRE_CERT),
+            _ldap.OPT_X_TLS_DEMAND
+        )
+
+    @requires_tls()
     def test_tls_ext_noca(self):
         l = self._open_conn(bind=False)
         l.set_option(_ldap.OPT_PROTOCOL_VERSION, _ldap.VERSION3)
+        # fails because libldap defaults to secure cert validation but
+        # the test CA is not installed as trust anchor.
         with self.assertRaises(_ldap.CONNECT_ERROR) as e:
             l.start_tls_s()
         # known resaons:

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -10,13 +10,12 @@ from __future__ import unicode_literals
 import os
 import unittest
 
-from slapdtest import SlapdTestCase, requires_tls
-
 # Switch off processing .ldaprc or ldap.conf before importing _ldap
 os.environ['LDAPNOINIT'] = '1'
 
 # import the plain C wrapper module
 import _ldap
+from slapdtest import SlapdTestCase, requires_tls
 
 
 class TestLdapCExtension(SlapdTestCase):

--- a/Tests/t_cidict.py
+++ b/Tests/t_cidict.py
@@ -5,11 +5,13 @@ Automatic tests for python-ldap's module ldap.cidict
 See https://www.python-ldap.org/ for details.
 """
 
-# from Python's standard lib
+import os
 import unittest
 
-# from python-ldap
-import ldap, ldap.cidict
+# Switch off processing .ldaprc or ldap.conf before importing _ldap
+os.environ['LDAPNOINIT'] = '1'
+import ldap
+import ldap.cidict
 
 
 class TestCidict(unittest.TestCase):

--- a/Tests/t_edit.py
+++ b/Tests/t_edit.py
@@ -9,10 +9,15 @@ else:
     PY2 = False
     text_type = str
 
-import ldap, unittest
-from slapdtest import SlapdTestCase
+import os
+import unittest
 
+# Switch off processing .ldaprc or ldap.conf before importing _ldap
+os.environ['LDAPNOINIT'] = '1'
+
+import ldap
 from ldap.ldapobject import LDAPObject
+from slapdtest import SlapdTestCase
 
 
 class EditionTests(SlapdTestCase):

--- a/Tests/t_ldap_controls_libldap.py
+++ b/Tests/t_ldap_controls_libldap.py
@@ -4,7 +4,6 @@ import unittest
 # Switch off processing .ldaprc or ldap.conf before importing _ldap
 os.environ['LDAPNOINIT'] = '1'
 
-import ldap
 from ldap.controls import pagedresults
 from ldap.controls import libldap
 

--- a/Tests/t_ldap_dn.py
+++ b/Tests/t_ldap_dn.py
@@ -8,9 +8,11 @@ See https://www.python-ldap.org/ for details.
 from __future__ import unicode_literals
 
 # from Python's standard lib
+import os
 import unittest
 
-# from python-ldap
+# Switch off processing .ldaprc or ldap.conf before importing _ldap
+os.environ['LDAPNOINIT'] = '1'
 import ldap.dn
 
 

--- a/Tests/t_ldap_filter.py
+++ b/Tests/t_ldap_filter.py
@@ -5,10 +5,12 @@ Automatic tests for python-ldap's module ldap.filter
 See https://www.python-ldap.org/ for details.
 """
 
-# from Python's standard lib
+import os
 import unittest
 
-# from python-ldap
+# Switch off processing .ldaprc or ldap.conf before importing _ldap
+os.environ['LDAPNOINIT'] = '1'
+
 from ldap.filter import escape_filter_chars
 
 

--- a/Tests/t_ldap_functions.py
+++ b/Tests/t_ldap_functions.py
@@ -5,10 +5,12 @@ Automatic tests for python-ldap's module ldap.functions
 See https://www.python-ldap.org/ for details.
 """
 
-# from Python's standard lib
+import os
 import unittest
 
-# from python-ldap
+# Switch off processing .ldaprc or ldap.conf before importing _ldap
+os.environ['LDAPNOINIT'] = '1'
+
 import ldap
 from ldap.dn import escape_dn_chars
 from ldap.filter import escape_filter_chars

--- a/Tests/t_ldap_modlist.py
+++ b/Tests/t_ldap_modlist.py
@@ -5,11 +5,15 @@ Automatic tests for python-ldap's module ldap.modlist
 See https://www.python-ldap.org/ for details.
 """
 
+import os
 import unittest
 
-import ldap
+# Switch off processing .ldaprc or ldap.conf before importing _ldap
+os.environ['LDAPNOINIT'] = '1'
 
+import ldap
 from ldap.modlist import addModlist,modifyModlist
+
 
 class TestModlist(unittest.TestCase):
 

--- a/Tests/t_ldap_options.py
+++ b/Tests/t_ldap_options.py
@@ -4,12 +4,14 @@ import unittest
 # Switch off processing .ldaprc or ldap.conf before importing _ldap
 os.environ['LDAPNOINIT'] = '1'
 
+from slapdtest import SlapdTestCase, requires_tls
+
 import ldap
 from ldap.controls import RequestControlTuples
 from ldap.controls.pagedresults import SimplePagedResultsControl
 from ldap.controls.openldap import SearchNoOpControl
 from ldap.ldapobject import SimpleLDAPObject
-from slapdtest import SlapdTestCase, requires_tls
+
 
 SENTINEL = object()
 

--- a/Tests/t_ldap_sasl.py
+++ b/Tests/t_ldap_sasl.py
@@ -5,7 +5,6 @@ Automatic tests for python-ldap's module ldap.sasl
 See https://www.python-ldap.org/ for details.
 """
 import os
-import socket
 import unittest
 
 # Switch off processing .ldaprc or ldap.conf before importing _ldap

--- a/Tests/t_ldap_schema_tokenizer.py
+++ b/Tests/t_ldap_schema_tokenizer.py
@@ -5,7 +5,11 @@ Automatic tests for python-ldap's module ldap.schema.tokenizer
 See https://www.python-ldap.org/ for details.
 """
 
+import os
 import unittest
+
+# Switch off processing .ldaprc or ldap.conf before importing _ldap
+os.environ['LDAPNOINIT'] = '1'
 
 import ldap.schema
 

--- a/Tests/t_ldap_syncrepl.py
+++ b/Tests/t_ldap_syncrepl.py
@@ -16,14 +16,14 @@ if sys.version_info[0] <= 2:
 else:
     PY2 = False
 
-from slapdtest import SlapdObject, SlapdTestCase
-
 # Switch off processing .ldaprc or ldap.conf before importing _ldap
 os.environ['LDAPNOINIT'] = '1'
 
 import ldap
 from ldap.ldapobject import SimpleLDAPObject
 from ldap.syncrepl import SyncreplConsumer
+
+from slapdtest import SlapdObject, SlapdTestCase
 
 # a template string for generating simple slapd.conf file
 SLAPD_CONF_PROVIDER_TEMPLATE = r"""

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -22,14 +22,16 @@ import os
 import unittest
 import warnings
 import pickle
-from slapdtest import SlapdTestCase
-from slapdtest import requires_ldapi, requires_sasl, requires_tls
 
 # Switch off processing .ldaprc or ldap.conf before importing _ldap
 os.environ['LDAPNOINIT'] = '1'
 
 import ldap
 from ldap.ldapobject import SimpleLDAPObject, ReconnectLDAPObject
+
+from slapdtest import SlapdTestCase
+from slapdtest import requires_ldapi, requires_sasl, requires_tls
+
 
 LDIF_TEMPLATE = """dn: %(suffix)s
 objectClass: dcObject

--- a/Tests/t_ldapurl.py
+++ b/Tests/t_ldapurl.py
@@ -7,7 +7,12 @@ See https://www.python-ldap.org/ for details.
 
 from __future__ import unicode_literals
 
+import os
 import unittest
+
+# Switch off processing .ldaprc or ldap.conf before importing _ldap
+os.environ['LDAPNOINIT'] = '1'
+
 from ldap.compat import quote
 
 import ldapurl

--- a/Tests/t_ldif.py
+++ b/Tests/t_ldif.py
@@ -7,16 +7,18 @@ See https://www.python-ldap.org/ for details.
 
 from __future__ import unicode_literals
 
-# from Python's standard lib
-import unittest
+import os
 import textwrap
+import unittest
 
 try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
 
-# from python-ldap
+# Switch off processing .ldaprc or ldap.conf before importing _ldap
+os.environ['LDAPNOINIT'] = '1'
+
 import ldif
 
 

--- a/Tests/t_untested_mods.py
+++ b/Tests/t_untested_mods.py
@@ -1,5 +1,10 @@
 # modules without any tests
 
+import os
+
+# Switch off processing .ldaprc or ldap.conf before importing _ldap
+os.environ['LDAPNOINIT'] = '1'
+
 import ldap.controls.deref
 import ldap.controls.openldap
 import ldap.controls.ppolicy


### PR DESCRIPTION
All test suites are now setting LDAPNOINIT to prevent processing of
/etc/openldap/ldap.conf. This fixes TLS tests when ldap.conf contains a
relaxed TLS_REQCERT option.

Now test that the default value for cert validation is DEMAND.