### PR TITLE
Add bytes_strictness to allow configuring behavior on bytes/text mismatch

### DIFF
--- a/Doc/bytes_mode.rst
+++ b/Doc/bytes_mode.rst
@@ -43,37 +43,47 @@ Encoding/decoding to other formats – text, images, etc. – is left to the cal
 The bytes mode
 --------------
 
-The behavior of python-ldap 3.0 in Python 2 is influenced by a ``bytes_mode``
-argument to :func:`ldap.initialize`.
-The argument can take these values:
+In Python 3, text values are represented as ``str``, the Unicode text type.
 
-``bytes_mode=True``: backwards-compatible
+In Python 2, the behavior of python-ldap 3.0 is influenced by a ``bytes_mode``
+argument to :func:`ldap.initialize`:
 
-    Text values returned from python-ldap are always bytes (``str``).
-    Text values supplied to python-ldap may be either bytes or Unicode.
-    The encoding for bytes is always assumed to be UTF-8.
+``bytes_mode=True`` (backwards compatible):
+    Text values are represented as bytes (``str``) encoded using UTF-8.
 
-    Not available in Python 3.
+``bytes_mode=False`` (future compatible):
+    Text values are represented as ``unicode``.
 
-``bytes_mode=False``: strictly future-compatible
-
-    Text values must be represented as ``unicode``.
-    An error is raised if python-ldap receives a text value as bytes (``str``).
-
-Unspecified: relaxed mode with warnings
-
-    Causes a warning on Python 2.
-
-    Text values returned from python-ldap are always ``unicode``.
-    Text values supplied to python-ldap should be ``unicode``;
-    warnings are emitted when they are not.
-
-    The warnings are of type :class:`~ldap.LDAPBytesWarning`, which
-    is a subclass of :class:`BytesWarning` designed to be easily
-    :ref:`filtered out <filter-bytes-warning>` if needed.
+If not given explicitly, python-ldap will default to ``bytes_mode=True``,
+but if an ``unicode`` value supplied to it, if will warn and use that value.
 
 Backwards-compatible behavior is not scheduled for removal until Python 2
 itself reaches end of life.
+
+
+Errors, warnings, and automatic encoding
+----------------------------------------
+
+While the type of values *returned* from python-ldap is always given by
+``bytes_mode``, the behavior for “wrong-type” values *passed in* can be
+controlled by the ``bytes_strictness`` argument to :func:`ldap.initialize`:
+
+``bytes_strictness='error'`` (default if ``bytes_mode`` is specified):
+  A ``TypeError`` is raised.
+
+``bytes_strictness='warn'`` (default when ``bytes_mode`` is not given explicitly):
+  A warning is raised, and the value is encoded/decoded
+  using the UTF-8 encoding.
+
+  The warnings are of type :class:`~ldap.LDAPBytesWarning`, which
+  is a subclass of :class:`BytesWarning` designed to be easily
+  :ref:`filtered out <filter-bytes-warning>` if needed.
+
+``bytes_strictness='silent'``:
+  The value is automatically encoded/decoded using the UTF-8 encoding.
+
+When setting ``bytes_strictness``, an explicit value for ``bytes_mode`` needs
+to be given as well.
 
 
 Porting recommendations

--- a/Doc/bytes_mode.rst
+++ b/Doc/bytes_mode.rst
@@ -65,8 +65,9 @@ Errors, warnings, and automatic encoding
 ----------------------------------------
 
 While the type of values *returned* from python-ldap is always given by
-``bytes_mode``, the behavior for “wrong-type” values *passed in* can be
-controlled by the ``bytes_strictness`` argument to :func:`ldap.initialize`:
+``bytes_mode``, for Python 2 the behavior for “wrong-type” values *passed in*
+can be controlled by the ``bytes_strictness`` argument to
+:func:`ldap.initialize`:
 
 ``bytes_strictness='error'`` (default if ``bytes_mode`` is specified):
   A ``TypeError`` is raised.
@@ -81,6 +82,9 @@ controlled by the ``bytes_strictness`` argument to :func:`ldap.initialize`:
 
 ``bytes_strictness='silent'``:
   The value is automatically encoded/decoded using the UTF-8 encoding.
+
+On Python 3, ``bytes_strictness`` is ignored and a ``TypeError`` is always
+raised.
 
 When setting ``bytes_strictness``, an explicit value for ``bytes_mode`` needs
 to be given as well.

--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -29,7 +29,7 @@ Functions
 
 This module defines the following functions:
 
-.. py:function:: initialize(uri [, trace_level=0 [, trace_file=sys.stdout [, trace_stack_limit=None, [bytes_mode=None]]]]) -> LDAPObject object
+.. py:function:: initialize(uri [, trace_level=0 [, trace_file=sys.stdout [, trace_stack_limit=None, [bytes_mode=None, [bytes_strictness=None]]]]]) -> LDAPObject object
 
    Initializes a new connection object for accessing the given LDAP server,
    and return an LDAP object (see :ref:`ldap-objects`) used to perform operations
@@ -53,7 +53,8 @@ This module defines the following functions:
    *trace_file* specifies a file-like object as target of the debug log and
    *trace_stack_limit* specifies the stack limit of tracebacks in debug log.
 
-   The *bytes_mode* argument specifies text/bytes behavior under Python 2.
+   The *bytes_mode* and *bytes_strictness* arguments specify text/bytes
+   behavior under Python 2.
    See :ref:`text-bytes` for a complete documentation.
 
    Possible values for *trace_level* are

--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -697,6 +697,9 @@ and wait for and return with the server's result, or with
 
    *serverctrls* and *clientctrls* like described in section :ref:`ldap-controls`.
 
+   The *dn* argument, and mod_type (second item) of *modlist* are text strings;
+   see :ref:`bytes_mode`.
+
 
 .. py:method:: LDAPObject.bind(who, cred, method) -> int
 
@@ -738,6 +741,8 @@ and wait for and return with the server's result, or with
 
    *serverctrls* and *clientctrls* like described in section :ref:`ldap-controls`.
 
+   The *dn* and *attr* arguments are text strings; see :ref:`bytes_mode`.
+
    .. note::
 
       A design fault in the LDAP API prevents *value*
@@ -757,6 +762,8 @@ and wait for and return with the server's result, or with
    from a subsequent call to :py:meth:`result()`.
 
    *serverctrls* and *clientctrls* like described in section :ref:`ldap-controls`.
+
+   The *dn* argument is text string; see :ref:`bytes_mode`.
 
 
 .. py:method:: LDAPObject.extop(extreq[,serverctrls=None[,clientctrls=None]]]) -> int
@@ -811,6 +818,9 @@ and wait for and return with the server's result, or with
    You might want to look into sub-module :py:mod:`ldap.modlist` for
    generating *modlist*.
 
+   The *dn* argument, and mod_type (second item) of *modlist* are text strings;
+   see :ref:`bytes_mode`.
+
 
 .. py:method:: LDAPObject.modrdn(dn, newrdn [, delold=1]) -> int
 
@@ -826,6 +836,8 @@ and wait for and return with the server's result, or with
 
    This operation is emulated by :py:meth:`rename()` and :py:meth:`rename_s()` methods
    since the modrdn2* routines in the C library are deprecated.
+
+   The *dn* and *newrdn* arguments are text strings; see :ref:`bytes_mode`.
 
 
 .. py:method:: LDAPObject.passwd(user, oldpw, newpw [, serverctrls=None [, clientctrls=None]]) -> int
@@ -844,6 +856,8 @@ and wait for and return with the server's result, or with
    *serverctrls* and *clientctrls* like described in section :ref:`ldap-controls`.
 
    The asynchronous version returns the initiated message id.
+
+   The *user*, *oldpw* and *newpw* arguments are text strings; see :ref:`bytes_mode`.
 
    .. seealso::
 
@@ -865,6 +879,8 @@ and wait for and return with the server's result, or with
    whether the old RDN should be kept as an attribute of the entry or not.
 
    *serverctrls* and *clientctrls* like described in section :ref:`ldap-controls`.
+
+   The *dn* and *newdn* arguments are text strings; see :ref:`bytes_mode`.
 
 
 .. py:method:: LDAPObject.result([msgid=RES_ANY [, all=1 [, timeout=None]]]) -> 2-tuple
@@ -1016,11 +1032,12 @@ and wait for and return with the server's result, or with
 
    *serverctrls* and *clientctrls* like described in section :ref:`ldap-controls`.
 
+   The *who* and *cred* arguments are text strings; see :ref:`bytes_mode`.
+
    .. versionchanged:: 3.0
 
       :meth:`~LDAPObject.simple_bind` and :meth:`~LDAPObject.simple_bind_s`
       now accept ``None`` for *who* and *cred*, too.
-
 
 .. py:method:: LDAPObject.search(base, scope [,filterstr='(objectClass=*)' [, attrlist=None [, attrsonly=0]]]) ->int
 
@@ -1073,6 +1090,9 @@ and wait for and return with the server's result, or with
    *sizelimit* parameter when using :py:meth:`search_ext()`
    or :py:meth:`search_ext_s()` (client-side search limit). If non-zero
    not more than *sizelimit* results are returned by the server.
+
+   The *base* and *filterstr* arguments, and *attrlist* contents,
+   are text strings; see :ref:`bytes_mode`.
 
    .. versionchanged:: 3.0
 


### PR DESCRIPTION
See https://github.com/python-ldap/python-ldap/issues/166 for initial discussion, or the changed docs for what is added.

I've used `bytes_strictness` instead of `bytes_warnings`, since warnings is just one of the possible behaviors. The new name isn't perfect either, though.