### PR TITLE
Link with lber

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ extra_objects =
 
 # Example for full-featured build:
 # Support for StartTLS/LDAPS, SASL bind and reentrant libldap_r.
-libs = ldap_r
+libs = ldap_r lber
 
 # Installation options
 [install]


### PR DESCRIPTION
setup.cfg overrides settings in setup.py. Include lber in list of
libraries in setup.cfg, too.

Signed-off-by: Christian Heimes <cheimes@redhat.com>