### PR TITLE
Doc: Remove warning about unreleased version

### DIFF
--- a/Doc/installing.rst
+++ b/Doc/installing.rst
@@ -5,13 +5,6 @@
 Installing python-ldap
 ######################
 
-.. warning::
-
-    You are reading documentation for an unreleased version.
-
-    Following these instructions will currently get you version 2.5.2,
-    which does not support Python 3.
-
 
 Installing from PyPI
 ====================


### PR DESCRIPTION
3.0.0 final is out so the instructions should apply for `pip install`.