### PR TITLE
Use items() when appropriate in dict iteration

### DIFF
--- a/Lib/ldap/cidict.py
+++ b/Lib/ldap/cidict.py
@@ -35,8 +35,8 @@ class cidict(IterableUserDict):
     del self.data[lower_key]
 
   def update(self,dict):
-    for key in dict.keys():
-      self[key] = dict[key]
+    for key, value in dict.items():
+      self[key] = value
 
   def has_key(self,key):
     return key in self

--- a/Lib/ldap/cidict.py
+++ b/Lib/ldap/cidict.py
@@ -44,6 +44,9 @@ class cidict(IterableUserDict):
   def __contains__(self,key):
     return IterableUserDict.__contains__(self, key.lower())
 
+  def __iter__(self):
+    return iter(self.keys())
+
   def keys(self):
     return self._keys.values()
 

--- a/Lib/ldap/modlist.py
+++ b/Lib/ldap/modlist.py
@@ -13,14 +13,14 @@ def addModlist(entry,ignore_attr_types=None):
   """Build modify list for call of method LDAPObject.add()"""
   ignore_attr_types = {v.lower() for v in ignore_attr_types or []}
   modlist = []
-  for attrtype in entry.keys():
+  for attrtype, value in entry.items():
     if attrtype.lower() in ignore_attr_types:
       # This attribute type is ignored
       continue
     # Eliminate empty attr value strings in list
-    attrvaluelist = [item for item in entry[attrtype] if item is not None]
+    attrvaluelist = [item for item in value if item is not None]
     if attrvaluelist:
-      modlist.append((attrtype,entry[attrtype]))
+      modlist.append((attrtype, value))
   return modlist # addModlist()
 
 
@@ -52,13 +52,13 @@ def modifyModlist(
   attrtype_lower_map = {}
   for a in old_entry.keys():
     attrtype_lower_map[a.lower()]=a
-  for attrtype in new_entry.keys():
+  for attrtype, value in new_entry.items():
     attrtype_lower = attrtype.lower()
     if attrtype_lower in ignore_attr_types:
       # This attribute type is ignored
       continue
     # Filter away null-strings
-    new_value = [item for item in new_entry[attrtype] if item is not None]
+    new_value = [item for item in value if item is not None]
     if attrtype_lower in attrtype_lower_map:
       old_value = old_entry.get(attrtype_lower_map[attrtype_lower],[])
       old_value = [item for item in old_value if item is not None]
@@ -88,10 +88,10 @@ def modifyModlist(
   if not ignore_oldexistent:
     # Remove all attributes of old_entry which are not present
     # in new_entry at all
-    for a in attrtype_lower_map.keys():
+    for a, val in attrtype_lower_map.items():
       if a in ignore_attr_types:
         # This attribute type is ignored
         continue
-      attrtype = attrtype_lower_map[a]
+      attrtype = val
       modlist.append((ldap.MOD_DELETE,attrtype,None))
   return modlist # modifyModlist()

--- a/Lib/ldap/schema/models.py
+++ b/Lib/ldap/schema/models.py
@@ -655,8 +655,8 @@ class Entry(IterableUserDict):
       return t
 
   def update(self,dict):
-    for key in dict.keys():
-      self[key] = dict[key]
+    for key, value in dict.values():
+      self[key] = value
 
   def __contains__(self,nameoroid):
     return self._at2key(nameoroid) in self.data

--- a/Lib/ldap/schema/subentry.py
+++ b/Lib/ldap/schema/subentry.py
@@ -136,8 +136,8 @@ class SubSchema:
     entry = {}
     # Collect the schema elements and store them in
     # entry's attributes
-    for se_class in self.sed.keys():
-      for se in self.sed[se_class].values():
+    for se_class, elements in self.sed.items():
+      for se in elements.values():
         se_str = str(se)
         try:
           entry[SCHEMA_ATTR_MAPPING[se_class]].append(se_str)
@@ -153,8 +153,7 @@ class SubSchema:
     avail_se = self.sed[schema_element_class]
     if schema_element_filters:
       result = []
-      for se_key in avail_se.keys():
-        se = avail_se[se_key]
+      for se_key, se in avail_se.items():
         for fk,fv in schema_element_filters:
           try:
             if getattr(se,fk) in fv:

--- a/Lib/ldapurl.py
+++ b/Lib/ldapurl.py
@@ -313,9 +313,9 @@ class LDAPUrl(object):
         Dictionary containing a mapping from class attributes
         to default values
     """
-    for k in defaults.keys():
+    for k, value in defaults.items():
       if getattr(self,k) is None:
-        setattr(self,k,defaults[k])
+        setattr(self, k, value)
 
   def initializeUrl(self):
     """

--- a/Lib/ldif.py
+++ b/Lib/ldif.py
@@ -150,8 +150,8 @@ class LDIFWriter:
     entry
         dictionary holding an entry
     """
-    for attr_type in sorted(entry.keys()):
-      for attr_value in entry[attr_type]:
+    for attr_type, values in sorted(entry.items()):
+      for attr_value in values:
         self._unparseAttrTypeandValue(attr_type,attr_value)
 
   def _unparseChangeRecord(self,modlist):

--- a/Tests/t_cidict.py
+++ b/Tests/t_cidict.py
@@ -36,6 +36,8 @@ class TestCidict(unittest.TestCase):
         self.assertEqual(cix.get("xyz", None), 987)
         cix_keys = sorted(cix.keys())
         self.assertEqual(cix_keys, ['AbCDeF','xYZ'])
+        cix_keys = sorted(cix)
+        self.assertEqual(cix_keys, ['AbCDeF','xYZ'])
         cix_items = sorted(cix.items())
         self.assertEqual(cix_items, [('AbCDeF',123), ('xYZ',987)])
         del cix["abcdEF"]


### PR DESCRIPTION
When reviewing #138 I found some cases where `items()` would be more appropriate than `keys()` or iterating the dict itself.

The fix for `__iter__()` from #138 is included as a separate commit.