### PR TITLE
Rewrite cidict and LDAPUrlExtensions in terms of MutableMapping

### DIFF
--- a/Lib/ldap/cidict.py
+++ b/Lib/ldap/cidict.py
@@ -15,6 +15,7 @@ class cidict(MutableMapping):
     """
     Case-insensitive but case-respecting dictionary.
     """
+    __slots__ = ('_keys', '_data')
 
     def __init__(self, default=None):
         self._keys = {}

--- a/Lib/ldap/cidict.py
+++ b/Lib/ldap/cidict.py
@@ -5,9 +5,9 @@ names of variable case.
 
 See https://www.python-ldap.org/ for details.
 """
-from collections import MutableMapping
 import warnings
 
+from ldap.compat import MutableMapping
 from ldap import __version__
 
 

--- a/Lib/ldap/cidict.py
+++ b/Lib/ldap/cidict.py
@@ -58,6 +58,17 @@ class cidict(MutableMapping):
         """Compatibility with python-ldap 2.x"""
         return key in self
 
+    @property
+    def data(self):
+        """Compatibility with older IterableUserDict-based implementation"""
+        warnings.warn(
+            'ldap.cidict.cidict.data is an internal attribute; it may be ' +
+            'removed at any time',
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._data
+
 
 def strlist_minus(a,b):
   """

--- a/Lib/ldap/compat.py
+++ b/Lib/ldap/compat.py
@@ -10,6 +10,7 @@ if sys.version_info[0] < 3:
     from urllib import unquote as urllib_unquote
     from urllib import urlopen
     from urlparse import urlparse
+    from collections import MutableMapping
 
     def unquote(uri):
         """Specialized unquote that uses UTF-8 for parsing."""
@@ -33,6 +34,7 @@ else:
     IterableUserDict = UserDict
     from urllib.parse import quote, quote_plus, unquote, urlparse
     from urllib.request import urlopen
+    from collections.abc import MutableMapping
 
     def reraise(exc_type, exc_value, exc_traceback):
         """Re-raise an exception given information from sys.exc_info()

--- a/Lib/ldapurl.py
+++ b/Lib/ldapurl.py
@@ -149,8 +149,13 @@ class LDAPUrlExtensions(MutableMapping):
             Either LDAPUrlExtension instance, (critical,exvalue)
             or string'ed exvalue
         """
-        assert isinstance(value, LDAPUrlExtension)
-        assert name == value.extype
+        if not isinstance(value, LDAPUrlExtension):
+            raise TypeError("value must be LDAPUrlExtension, not "
+                            + type(value).__name__)
+        if name != value.extype:
+            raise ValueError(
+                "key {!r} does not match extension type {!r}".format(
+                    name, value.extype))
         self._data[name] = value
 
     def __getitem__(self, name):
@@ -177,9 +182,8 @@ class LDAPUrlExtensions(MutableMapping):
         )
 
     def __eq__(self,other):
-        assert isinstance(other, self.__class__), TypeError(
-            "other has to be instance of %s" % (self.__class__)
-            )
+        if not isinstance(other, self.__class__):
+            return NotImplemented
         return self._data == other._data
 
     def parse(self,extListStr):
@@ -374,17 +378,23 @@ class LDAPUrl(object):
     hrefTarget
         string added as link target attribute
     """
-    assert type(urlPrefix)==StringType, "urlPrefix must be StringType"
+    if not isinstance(urlPrefix, str):
+        raise TypeError("urlPrefix must be str, not "
+                        + type(urlPrefix).__name__)
     if hrefText is None:
-      hrefText = self.unparse()
-    assert type(hrefText)==StringType, "hrefText must be StringType"
+        hrefText = self.unparse()
+    if not isinstance(hrefText, str):
+        raise TypeError("hrefText must be str, not "
+                        + type(hrefText).__name__)
     if hrefTarget is None:
-      target = ''
+        target = ''
     else:
-      assert type(hrefTarget)==StringType, "hrefTarget must be StringType"
-      target = ' target="%s"' % hrefTarget
+        if not isinstance(hrefTarget, str):
+            raise TypeError("hrefTarget must be str, not "
+                            + type(hrefTarget).__name__)
+        target = ' target="%s"' % hrefTarget
     return '<a%s href="%s%s">%s</a>' % (
-      target,urlPrefix,self.unparse(),hrefText
+        target, urlPrefix, self.unparse(), hrefText
     )
 
   def __str__(self):

--- a/Lib/ldapurl.py
+++ b/Lib/ldapurl.py
@@ -144,10 +144,12 @@ class LDAPUrlExtensions(MutableMapping):
             self.update(default)
 
     def __setitem__(self, name, value):
-        """
+        """Store an extension
+
+        name
+            string
         value
-            Either LDAPUrlExtension instance, (critical,exvalue)
-            or string'ed exvalue
+            LDAPUrlExtension instance, whose extype nust match `name`
         """
         if not isinstance(value, LDAPUrlExtension):
             raise TypeError("value must be LDAPUrlExtension, not "

--- a/Lib/ldapurl.py
+++ b/Lib/ldapurl.py
@@ -137,6 +137,7 @@ class LDAPUrlExtensions(MutableMapping):
     Models a collection of LDAP URL extensions as
     a mapping type
     """
+    __slots__ = ('_data', )
 
     def __init__(self, default=None):
         self._data = {}

--- a/Lib/ldapurl.py
+++ b/Lib/ldapurl.py
@@ -16,9 +16,7 @@ __all__ = [
   'LDAPUrlExtension','LDAPUrlExtensions','LDAPUrl'
 ]
 
-from collections import MutableMapping
-
-from ldap.compat import quote, unquote
+from ldap.compat import quote, unquote, MutableMapping
 
 LDAP_SCOPE_BASE = 0
 LDAP_SCOPE_ONELEVEL = 1

--- a/Tests/t_cidict.py
+++ b/Tests/t_cidict.py
@@ -62,6 +62,16 @@ class TestCidict(unittest.TestCase):
                 strlist_func(["a"], ["b"])
             self.assertEqual(len(w), 1)
 
+    def test_cidict_data(self):
+        """test the deprecated data atrtribute"""
+        d = ldap.cidict.cidict({'A': 1, 'B': 2})
+        with warnings.catch_warnings(record=True) as w:
+            warnings.resetwarnings()
+            warnings.simplefilter('always', DeprecationWarning)
+            data = d.data
+        assert data == {'a': 1, 'b': 2}
+        self.assertEqual(len(w), 1)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
he UserDict API is not specified when it comes to extending:
it is not clear which methods can be safely overridden.

The MutableMapping ABC fixes this problem by providing an explicit
set of abstract methods, in terms of which the rest of the API
is implemented.
