### PR TITLE
Trim white space throughout the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Auto-generated
 .*.swp
 *.pyc

--- a/Build/build-openbsd/Makefile
+++ b/Build/build-openbsd/Makefile
@@ -10,7 +10,7 @@ HOMEPAGE=		https://www.python-ldap.org/
 FAKE=			Yes
 CONFIGURE_STYLE=	gnu
 SEPARATE_BUILD=		Yes
-EXTRACT_ONLY=	
+EXTRACT_ONLY=
 
 CONFIGURE_ARGS+=	--with-ldap=${LOCALBASE}
 

--- a/Build/build-openbsd/pkg/DESCR
+++ b/Build/build-openbsd/pkg/DESCR
@@ -1,2 +1,2 @@
-This Python library provides access to the LDAP (Lightweight Directory Access 
+This Python library provides access to the LDAP (Lightweight Directory Access
 Protocol) RFC1823 C interface.

--- a/Build/setup.cfg.mingw
+++ b/Build/setup.cfg.mingw
@@ -15,8 +15,8 @@ defines = WIN32
 library_dirs = C:/msys/1.0/home/mcicogni/openldap-mingw-build-4/openldap-2.2.18/libraries/libldap_r/.libs C:/msys/1.0/home/mcicogni/openldap-mingw-build-4/openldap-2.2.18/libraries/liblber/.libs C:\msys\1.0\home\mcicogni\openldap-mingw-build-4\openssl-0.9.7e
 include_dirs = C:/msys/1.0/home/mcicogni/openldap-mingw-build-4/openldap-2.2.18/include
 
-extra_compile_args = 
-extra_objects = 
+extra_compile_args =
+extra_objects =
 
 libs = ldap_r lber ssl crypto ws2_32 gdi32
 

--- a/Build/setup.cfg.suse-linux
+++ b/Build/setup.cfg.suse-linux
@@ -8,7 +8,7 @@
 library_dirs = /usr/lib/sasl2
 include_dirs = /usr/include/sasl
 
-extra_compile_args = 
+extra_compile_args =
 extra_objects =
 
 # Example for full-featured SuSE build:

--- a/Demo/Lib/ldap/async/deltree.py
+++ b/Demo/Lib/ldap/async/deltree.py
@@ -5,7 +5,7 @@ import ldap,ldap.async
 class DeleteLeafs(ldap.async.AsyncSearchHandler):
   """
   Class for deleting entries which are results of a search.
-  
+
   DNs of Non-leaf entries are collected in DeleteLeafs.nonLeafEntries.
   """
   _entryResultTypes = ldap.async._entryResultTypes

--- a/Demo/Lib/ldif/ldifcopy.py
+++ b/Demo/Lib/ldif/ldifcopy.py
@@ -20,4 +20,3 @@ ldif_collector = ldif.LDIFCopy(
   process_url_schemes=['file','ftp','http']
 )
 ldif_collector.parse()
-

--- a/Demo/matchedvalues.py
+++ b/Demo/matchedvalues.py
@@ -61,4 +61,3 @@ print_result(res)
 res = ld.search_ext_s(base, scope, filter, attrlist = ['mail'], serverctrls = [mv])
 print("Matched values control: %s" % control_filter)
 print_result(res)
-

--- a/Demo/options.py
+++ b/Demo/options.py
@@ -24,7 +24,3 @@ l.set_option(ldap.OPT_TIMELIMIT,60)
 #print("time limit:",l.get_option(ldap.OPT_TIMELIMIT))
 print("Binding...")
 l.simple_bind_s("","")
-
-
-
-

--- a/Demo/pyasn1/sessiontrack.py
+++ b/Demo/pyasn1/sessiontrack.py
@@ -58,4 +58,3 @@ ldap_conn.search_ext_s(
   ldap_url.attrs or ['*'],
   serverctrls=[st_ctrl]
 )
-

--- a/Demo/pyasn1/syncrepl.py
+++ b/Demo/pyasn1/syncrepl.py
@@ -93,8 +93,8 @@ class SyncReplClient(ReconnectLDAPObject, SyncreplConsumer):
         # If we have not been given any UUID values,
         # then we have recieved all the present controls...
         if uuids is None:
-            # We only do things if refreshDeletes is false as the syncrepl 
-            # extension will call syncrepl_delete instead when it detects a 
+            # We only do things if refreshDeletes is false as the syncrepl
+            # extension will call syncrepl_delete instead when it detects a
             # delete notice
             if refreshDeletes is False:
                 deletedEntries = [

--- a/Demo/schema.py
+++ b/Demo/schema.py
@@ -47,7 +47,7 @@ try:
     attr_type_filter = [
       ('no_user_mod',[0]),
       ('usage',range(2)),
-    ]  
+    ]
   )
 except KeyError as e:
   print('***KeyError',str(e))

--- a/Demo/schema_tree.py
+++ b/Demo/schema_tree.py
@@ -98,4 +98,3 @@ else:
 
   print('\n*** Attribute types tree ***\n')
   PrintSchemaTree(schema,ldap.schema.AttributeType,at_tree,'_',0)
-

--- a/Demo/simple.py
+++ b/Demo/simple.py
@@ -97,11 +97,10 @@ l.add_s(dn,
 #
 
 res = l.search_s(
-	"ou=CSEE, o=UQ, c=AU", 
-	_ldap.SCOPE_SUBTREE, 
+	"ou=CSEE, o=UQ, c=AU",
+	_ldap.SCOPE_SUBTREE,
 	"objectclass=*",
       )
 print(res)
 
 l.unbind()
-

--- a/Demo/simplebrowse.py
+++ b/Demo/simplebrowse.py
@@ -50,7 +50,7 @@ while 1:
 		# We're not interested in attributes at this stage, so
 		# we specify [] as the list of attribute names to retreive.
 		#
-		for name,attrs in l.search_s(dn, ldap.SCOPE_ONELEVEL, 
+		for name,attrs in l.search_s(dn, ldap.SCOPE_ONELEVEL,
 		    "objectclass=*", []):
 			#-- shorten resulting dns for output brevity
 			if name.startswith(dn+", "):
@@ -100,7 +100,7 @@ while 1:
 			print("  %-24s" % name)
 			for k,vals in attrs.items():
 			    for v in vals:
-				if len(v) > 200: 
+				if len(v) > 200:
 					v = `v[:200]` + \
 						("... (%d bytes)" % len(v))
 				else:
@@ -125,4 +125,3 @@ while 1:
 
     except:
 	print_exc()
-

--- a/Doc/installing.rst
+++ b/Doc/installing.rst
@@ -246,4 +246,3 @@ Debugging symbols are preserved with compile option ``-g``.
   extra_objects =
 
   libs = ldap_r lber sasl2 ssl crypto
-

--- a/Doc/reference/ldap-async.rst
+++ b/Doc/reference/ldap-async.rst
@@ -112,4 +112,3 @@ for writing search results as LDIF to stdout. ::
        s.endResultBreak-s.beginResultsDropped
      )
    )
-

--- a/Doc/reference/ldap-dn.rst
+++ b/Doc/reference/ldap-dn.rst
@@ -107,4 +107,3 @@ Splitting a LDAPv3 DN with a multi-valued RDN into its AVA parts:
 
 >>> ldap.dn.str2dn('cn=John Doe+mail=john.doe@example.com,dc=example,dc=com')
 [[('cn', 'John Doe', 1), ('mail', 'john.doe@example.com', 1)], [('dc', 'example', 1)], [('dc', 'com', 1)]]
-

--- a/Doc/reference/ldap-extop.rst
+++ b/Doc/reference/ldap-extop.rst
@@ -38,4 +38,3 @@ This requires :py:mod:`pyasn1` and :py:mod:`pyasn1_modules` to be installed.
 
 .. autoclass:: ldap.extop.dds.RefreshResponse
    :members:
-

--- a/Doc/reference/ldap-filter.rst
+++ b/Doc/reference/ldap-filter.rst
@@ -35,4 +35,3 @@ The :mod:`ldap.filter` module defines the following functions:
    whole filter string.
 
    .. % -> string
-

--- a/Doc/reference/ldap-sasl.rst
+++ b/Doc/reference/ldap-sasl.rst
@@ -35,7 +35,7 @@ Classes
 
 .. autoclass:: ldap.sasl.sasl
    :members:
-   
+
    This class is used with :py:meth:`ldap.LDAPObject.sasl_interactive_bind_s()`.
 
 
@@ -82,4 +82,3 @@ and sends a SASL external bind request.
    ldap_conn.sasl_non_interactive_bind_s('EXTERNAL')
    # Find out the SASL Authorization Identity
    print ldap_conn.whoami_s()
-

--- a/Doc/reference/ldap-syncrepl.rst
+++ b/Doc/reference/ldap-syncrepl.rst
@@ -20,4 +20,3 @@ This module defines the following classes:
 
 .. autoclass:: ldap.syncrepl.SyncreplConsumer
    :members:
-

--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -968,7 +968,7 @@ and wait for and return with the server's result, or with
 .. py:method:: LDAPObject.sasl_interactive_bind_s(who, auth[, serverctrls=None [, clientctrls=None [, sasl_flags=ldap.SASL_QUIET]]]) -> None
 
    This call is used to bind to the directory with a SASL bind request.
-   
+
    *auth* is an :py:class:`ldap.sasl.sasl()` instance.
 
    *serverctrls* and *clientctrls* like described in section :ref:`ldap-controls`.
@@ -1079,7 +1079,7 @@ and wait for and return with the server's result, or with
    .. versionchanged:: 3.0
 
       ``filterstr=None`` is equivalent to ``filterstr='(objectClass=*)'``.
-   
+
 
 .. py:method:: LDAPObject.start_tls_s() -> None
 
@@ -1220,4 +1220,3 @@ subtree search.
 >>> for dn,entry in r:
 >>>   print('Processing',repr(dn))
 >>>   handle_ldap_entry(entry)
-

--- a/Doc/reference/ldapurl.rst
+++ b/Doc/reference/ldapurl.rst
@@ -124,4 +124,3 @@ with \module{ldapurl} module.
 >>> ldap_url = ldapurl.LDAPUrl(hostport='localhost:1389',dn='dc=stroeder,dc=com',attrs=['cn','mail'],who='cn=Michael,dc=stroeder,dc=com',cred='secret')
 >>> ldap_url.unparse()
 'ldap://localhost:1389/dc=stroeder,dc=com?cn,mail?base?(objectclass=*)?bindname=cn=Michael%2Cdc=stroeder%2Cdc=com,X-BINDPW=secret'
-

--- a/Doc/reference/ldif.rst
+++ b/Doc/reference/ldif.rst
@@ -94,4 +94,3 @@ with :mod:`ldif` module, skip some entries and write the result to stdout. ::
 
    parser = MyLDIF(open("input.ldif", 'rb'), sys.stdout)
    parser.parse()
-

--- a/Doc/sample_workflow.rst
+++ b/Doc/sample_workflow.rst
@@ -1,4 +1,3 @@
-
 .. _sample workflow:
 
 Sample workflow for python-ldap development

--- a/Lib/ldap/constants.py
+++ b/Lib/ldap/constants.py
@@ -16,7 +16,7 @@ The information serves two purposes:
 from __future__ import print_function
 
 class Constant(object):
-    """Base class for a definition of an OpenLDAP constant 
+    """Base class for a definition of an OpenLDAP constant
     """
 
     def __init__(self, name, optional=False, requirements=(), doc=None):

--- a/Lib/ldap/controls/deref.py
+++ b/Lib/ldap/controls/deref.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-ldap.controls.deref - classes for 
+ldap.controls.deref - classes for
 (see https://tools.ietf.org/html/draft-masarati-ldap-deref)
 
 See https://www.python-ldap.org/ for project details.

--- a/Lib/ldapurl.py
+++ b/Lib/ldapurl.py
@@ -429,4 +429,3 @@ class LDAPUrl(object):
           pass
     else:
       del self.__dict__[name]
-

--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -54,8 +54,8 @@ dealloc(LDAPObject *self)
  * utility functions
  */
 
-/* 
- * check to see if the LDAPObject is valid, 
+/*
+ * check to see if the LDAPObject is valid,
  * ie has been opened, and not closed. An exception is set if not valid.
  */
 
@@ -89,8 +89,8 @@ LDAPMod_DEL(LDAPMod *lm)
     PyMem_DEL(lm);
 }
 
-/* 
- * convert a tuple of the form (int,str,[str,...]) 
+/*
+ * convert a tuple of the form (int,str,[str,...])
  * or (str, [str,...]) if no_op is true, into an LDAPMod structure.
  * See ldap_modify(3) for details.
  *
@@ -208,8 +208,8 @@ LDAPMods_DEL(LDAPMod **lms)
     PyMem_DEL(lms);
 }
 
-/* 
- * convert a list of tuples into a LDAPMod*[] array structure 
+/*
+ * convert a list of tuples into a LDAPMod*[] array structure
  * NOTE: list of tuples must live longer than the LDAPMods
  */
 
@@ -589,7 +589,7 @@ l_ldap_simple_bind(LDAPObject *self, PyObject *args)
      auth modules ("mechanisms"), or try
 
        ldapsearch   -b "" -s base -LLL -x  supportedSASLMechanisms
-     
+
      (perhaps with an additional -h and -p argument for ldap host and
      port). The latter will show you which SASL mechanisms are known
      to the LDAP server. If you do not want to set up Kerberos, you
@@ -645,7 +645,7 @@ interaction(unsigned flags, sasl_interact_t *interact, PyObject *SASLObject)
     return LDAP_SUCCESS;
 }
 
-/* 
+/*
   This function will be called by ldap_sasl_interactive_bind(). The
   "*in" is an array of sasl_interact_t's (see sasl.h for a
   reference). The last interact in the array has an interact->id of
@@ -748,12 +748,12 @@ l_ldap_sasl_interactive_bind_s(LDAPObject *self, PyObject *args)
 
     static unsigned sasl_flags = LDAP_SASL_QUIET;
 
-    /* 
+    /*
      * In Python 2.3+, a "I" format argument indicates that we're either converting
      * the Python object into a long or an unsigned int. In versions prior to that,
      * it will always convert to a long. Since the sasl_flags variable is an
      * unsigned int, we need to use the "I" flag if we're running Python 2.3+ and a
-     * "i" otherwise. 
+     * "i" otherwise.
      */
 #if (PY_MAJOR_VERSION == 2) && (PY_MINOR_VERSION < 3)
     if (!PyArg_ParseTuple

--- a/Tests/t_ldap_asyncsearch.py
+++ b/Tests/t_ldap_asyncsearch.py
@@ -22,4 +22,3 @@ class TestLdapAsyncSearch(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/Tests/t_ldap_sasl.py
+++ b/Tests/t_ldap_sasl.py
@@ -94,4 +94,3 @@ class TestSasl(SlapdTestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/Tests/t_ldif.py
+++ b/Tests/t_ldif.py
@@ -467,7 +467,7 @@ class TestEntryRecords(TestLDIFParser):
             """
 
             # comment before version
-               
+
             version: 1
 
 
@@ -586,7 +586,7 @@ class TestChangeRecords(TestLDIFParser):
             """
 
             # comment before version
-               
+
             version: 1
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,8 +14,8 @@
 # ./configure --with-cyrus-sasl --with-tls
 defines = HAVE_SASL HAVE_TLS HAVE_LIBLDAP_R
 
-extra_compile_args = 
-extra_objects = 
+extra_compile_args =
+extra_objects =
 
 # Example for full-featured build:
 # Support for StartTLS/LDAPS, SASL bind and reentrant libldap_r.

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
   from Python programs. Mainly it wraps the OpenLDAP 2.x libs for that purpose.
   Additionally the package contains modules for other LDAP-related stuff
   (e.g. processing LDIF, LDAPURLs, LDAPv3 schema, LDAPv3 extended operations
-  and controls, etc.). 
+  and controls, etc.).
   """,
   author = 'python-ldap project',
   author_email = 'python-ldap@python.org',

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ minver = 1.8
 [testenv]
 deps = coverage
 passenv = WITH_GCOV
-# - Enable BytesWarning 
+# - Enable BytesWarning
 # - Turn all warnings into exceptions.
 # - 'ignore:the imp module is deprecated' is required to ignore import of 'imp'
 #   in distutils. Python < 3.6 use PendingDeprecationWarning; Python >= 3.6 use


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all in one go, it helps keep future diffs cleaner by avoiding spurious white space changes on unrelated lines.

---

This PR is a followup based on the comment, https://github.com/python-ldap/python-ldap/pull/118#issuecomment-351004561

Now that 3.0 has been released and other project wide changes, have landed, I'm hoping now is a good time.