### PR TITLE
Remove assignment of variable to itself

### DIFF
--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -566,7 +566,6 @@ class SlapdTestCase(unittest.TestCase):
     def setUpClass(cls):
         cls.server = cls.server_class()
         cls.server.start()
-        cls.server = cls.server
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Looks like a simple mistake. Introduced in 2ce408cf8b7d5b084556de0d36bf5666c1fda515.