### PR TITLE
Tests: Disable warnings-as-errors for Python 3.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,12 @@ passenv = {[testenv]passenv}
 commands = {envpython} \
     -m coverage run --parallel setup.py test
 
+[testenv:py34]
+# No warnings with Python 3.4
+passenv = {[testenv]passenv}
+commands = {envpython} \
+    -m coverage run --parallel setup.py test
+
 [testenv:py2-nosasltls]
 basepython = python2
 deps = {[testenv]deps}


### PR DESCRIPTION
Python 3.4 is in its security fix only phase. We should make sure
the tests pass, but warnings should no longer break CI.