### PR TITLE
Make SlapdObject a context manager

### DIFF
--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -164,6 +164,10 @@ class SlapdObject(object):
 
     When a reference to an instance of this class is lost, the slapd
     server is shut down.
+
+    An instance can be used as a context manager. When exiting the context
+    manager, the slapd server is shut down and the temporary data store is
+    removed.
     """
     slapd_conf_template = SLAPD_CONF_TEMPLATE
     database = 'mdb'
@@ -552,6 +556,13 @@ class SlapdObject(object):
             extra_args.append('-r')
         extra_args.append(dn)
         self._cli_popen(self.PATH_LDAPDELETE, extra_args=extra_args)
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop()
 
 
 class SlapdTestCase(unittest.TestCase):

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -168,6 +168,10 @@ class SlapdObject(object):
     An instance can be used as a context manager. When exiting the context
     manager, the slapd server is shut down and the temporary data store is
     removed.
+
+    .. versionchanged:: 3.1
+
+        Added context manager functionality
     """
     slapd_conf_template = SLAPD_CONF_TEMPLATE
     database = 'mdb'

--- a/Tests/t_slapdobject.py
+++ b/Tests/t_slapdobject.py
@@ -1,0 +1,18 @@
+import unittest
+
+import slapdtest
+
+
+class TestSlapdObject(unittest.TestCase):
+    def test_context_manager(self):
+        with slapdtest.SlapdObject() as server:
+            self.assertIsNotNone(server._proc)
+        self.assertIsNone(server._proc)
+
+    def test_context_manager_after_start(self):
+        server = slapdtest.SlapdObject()
+        server.start()
+        self.assertIsNotNone(server._proc)
+        with server:
+            self.assertIsNotNone(server._proc)
+        self.assertIsNone(server._proc)


### PR DESCRIPTION
Allows for automatic cleanup of resources using the with statement. For example:

```py
   with slapdtest.SlapdObject() as server:
       server.ldapadd(...)
       ...
```

When using `SlapdObject` in a function, it is more convenient and concise than using a `try`/`finally` pattern.