### PR TITLE
Stop catching ImportError for pyasn1

### DIFF
--- a/Lib/ldap/controls/__init__.py
+++ b/Lib/ldap/controls/__init__.py
@@ -17,10 +17,7 @@ assert _ldap.__version__==__version__, \
 
 import ldap
 
-try:
-  from pyasn1.error import PyAsn1Error
-except ImportError:
-  PyAsn1Error = None
+from pyasn1.error import PyAsn1Error
 
 
 __all__ = [

--- a/Lib/ldap/extop/__init__.py
+++ b/Lib/ldap/extop/__init__.py
@@ -63,10 +63,5 @@ class ExtendedResponse:
     return value
 
 
-# Optionally import sub-modules which need pyasn1 et al
-try:
-  import pyasn1,pyasn1_modules.rfc2251
-except ImportError:
-  pass
-else:
-  from ldap.extop.dds import *
+# Import sub-modules
+from ldap.extop.dds import *


### PR DESCRIPTION
pyasn1 and pyasn1_modules are hard dependencies of python-ldap. They have been listed in `install_requires` since commit 5d158578ce5a01f159378294ae7a88af66d4a05b. As they are not optional, can expect imports to succeed.