### PR TITLE
Move import statements to top level

### DIFF
--- a/Lib/ldap/asyncsearch.py
+++ b/Lib/ldap/asyncsearch.py
@@ -8,6 +8,8 @@ import ldap
 
 from ldap import __version__
 
+import ldif
+
 SEARCH_RESULT_TYPES = {
   ldap.RES_SEARCH_ENTRY,
   ldap.RES_SEARCH_RESULT,
@@ -269,7 +271,6 @@ class LDIFWriter(FileWriter):
   """
 
   def __init__(self,l,writer_obj,headerStr='',footerStr=''):
-    import ldif
     if isinstance(writer_obj,ldif.LDIFWriter):
       self._ldif_writer = writer_obj
     else:

--- a/Lib/ldap/schema/subentry.py
+++ b/Lib/ldap/schema/subentry.py
@@ -4,9 +4,16 @@ ldap.schema.subentry -  subschema subentry handling
 See https://www.python-ldap.org/ for details.
 """
 
+import copy
+
 import ldap.cidict,ldap.schema
 
+from ldap.compat import urlopen
 from ldap.schema.models import *
+
+import ldapurl
+import ldif
+
 
 SCHEMA_CLASS_MAPPING = ldap.cidict.cidict()
 SCHEMA_ATTR_MAPPING = {}
@@ -256,7 +263,6 @@ class SubSchema:
     Get a schema element by name or OID with all class attributes
     set including inherited class attributes
     """
-    import copy
     inherited = inherited or []
     se = copy.copy(self.sed[se_class].get(self.getoid(se_class,nameoroid)))
     if se and hasattr(se,'sup'):
@@ -452,7 +458,6 @@ def urlfetch(uri,trace_level=0):
   """
   uri = uri.strip()
   if uri.startswith(('ldap:', 'ldaps:', 'ldapi:')):
-    import ldapurl
     ldap_url = ldapurl.LDAPUrl(uri)
 
     l=ldap.initialize(ldap_url.initializeUrl(),trace_level)
@@ -472,8 +477,6 @@ def urlfetch(uri,trace_level=0):
     l.unbind_s()
     del l
   else:
-    import ldif
-    from ldap.compat import urlopen
     ldif_file = urlopen(uri)
     ldif_parser = ldif.LDIFRecordList(ldif_file,max_entries=1)
     ldif_parser.parse()


### PR DESCRIPTION
For import statements that can safely exist at the top level of the file, move them there.

In `Lib/slapdtest/_slapdtest.py`, having imports local to functions unnecessarily resulted in duplicates.

This style is also more in line with PEP8:

https://www.python.org/dev/peps/pep-0008/#imports

> Imports are always put at the top of the file, just after any module comments and docstrings, and before module globals and constants.