### PR TITLE
Update Pytest cache directory in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 .coverage*
 !.coveragerc
 /.cache
+/.pytest_cache
 
 # shared libs installed by 'setup.py test'
 /Lib/*.so*


### PR DESCRIPTION
Starting with Pytest 3.4.0 (2018-01-30), Pytest's cache directory was renamed to `.pytest_cache`.

https://docs.pytest.org/en/latest/changelog.html#pytest-3-4-0-2018-01-30

> The default cache directory has been renamed from `.cache` to `.pytest_cache` after community feedback that the name `.cache` did not make it clear that it was used by pytest.