### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/Demo/pyasn1/README
+++ b/Demo/pyasn1/README
@@ -2,5 +2,5 @@ The sample modules/scripts herein require modules pyasn1 and pyasn1-modules.
 
 https://github.com/etingof/pyasn1
 
-https://pypi.python.org/pypi/pyasn1
-https://pypi.python.org/pypi/pyasn1-modules
+https://pypi.org/project/pyasn1/
+https://pypi.org/project/pyasn1-modules/

--- a/Doc/contributing.rst
+++ b/Doc/contributing.rst
@@ -143,7 +143,7 @@ keeps track of all reference increments and decrements. The leak plugin runs
 each test multiple times and checks if the reference count increases.
 
 .. _pytest: https://docs.pytest.org/en/latest/
-.. _pytest-leaks: https://pypi.python.org/pypi/pytest-leaks
+.. _pytest-leaks: https://pypi.org/project/pytest-leaks/
 
 Download and compile the *pydebug* build::
 

--- a/Doc/faq.rst
+++ b/Doc/faq.rst
@@ -26,7 +26,7 @@ Usage
   **A1**. For earlier versions, there's `pyldap`_, an independent fork
   now merged into python-ldap.
 
-.. _pyldap: https://pypi.python.org/pypi/pyldap
+.. _pyldap: https://pypi.org/project/pyldap/
 
 
 **Q**: Does it work with Python 2.6? (1.5|2.0|2.1|2.2|2.3|2.4|2.5)?

--- a/Doc/installing.rst
+++ b/Doc/installing.rst
@@ -15,7 +15,7 @@ For example::
 
     $ python -m pip install python-ldap
 
-.. _PyPI repository: https://pypi.python.org/pypi/python-ldap/
+.. _PyPI repository: https://pypi.org/project/python-ldap/
 .. _pip: https://pip.pypa.io/en/stable/
 
 For installing from PyPI, you will need the same :ref:`build prerequisites`
@@ -27,8 +27,8 @@ We do not currently provide pre-built packages (wheels).
 Furthermore, python-ldap requires the modules `pyasn1`_ and `pyasn1-modules`_.
 ``pip`` will install these automatically.
 
-.. _pyasn1: https://pypi.python.org/pypi/pyasn1
-.. _pyasn1-modules: https://pypi.python.org/pypi/pyasn1-modules
+.. _pyasn1: https://pypi.org/project/pyasn1/
+.. _pyasn1-modules: https://pypi.org/project/pyasn1-modules/
 
 
 Pre-built Binaries

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
   author = 'python-ldap project',
   author_email = 'python-ldap@python.org',
   url = 'https://www.python-ldap.org/',
-  download_url = 'https://pypi.python.org/pypi/python-ldap/',
+  download_url = 'https://pypi.org/project/python-ldap/',
   classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Developers',


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html