### PR TITLE
byte/text expectation in ldap.modlist test cases were obsolete in Python 3

### DIFF
--- a/Tests/t_ldap_modlist.py
+++ b/Tests/t_ldap_modlist.py
@@ -20,19 +20,19 @@ class TestModlist(unittest.TestCase):
     addModlist_tests = [
         (
             {
-                'objectClass':['person','pilotPerson'],
-                'cn':['Michael Str\303\266der','Michael Stroeder'],
-                'sn':['Str\303\266der'],
+                'objectClass': [b'person',b'pilotPerson'],
+                'cn':[b'Michael Str\303\266der',b'Michael Stroeder'],
+                'sn':[b'Str\303\266der'],
                 'dummy1':[],
-                'dummy2':['2'],
-                'dummy3':[''],
+                'dummy2':[b'2'],
+                'dummy3':[b''],
             },
             [
-                ('objectClass',['person','pilotPerson']),
-                ('cn',['Michael Str\303\266der','Michael Stroeder']),
-                ('sn',['Str\303\266der']),
-                ('dummy2',['2']),
-                ('dummy3',['']),
+                ('objectClass',[b'person',b'pilotPerson']),
+                ('cn',[b'Michael Str\303\266der',b'Michael Stroeder']),
+                ('sn',[b'Str\303\266der']),
+                ('dummy2',[b'2']),
+                ('dummy3',[b'']),
             ]
         ),
     ]
@@ -52,42 +52,42 @@ class TestModlist(unittest.TestCase):
     modifyModlist_tests = [
         (
             {
-                'objectClass':['person','pilotPerson'],
-                'cn':['Michael Str\303\266der','Michael Stroeder'],
-                'sn':['Str\303\266der'],
-                'enum':['a','b','c'],
-                'c':['DE'],
+                'objectClass':[b'person',b'pilotPerson'],
+                'cn':[b'Michael Str\303\266der',b'Michael Stroeder'],
+                'sn':[b'Str\303\266der'],
+                'enum':[b'a',b'b',b'c'],
+                'c':[b'DE'],
             },
             {
-                'objectClass':['person','inetOrgPerson'],
-                'cn':['Michael Str\303\266der','Michael Stroeder'],
+                'objectClass':[b'person',b'inetOrgPerson'],
+                'cn':[b'Michael Str\303\266der',b'Michael Stroeder'],
                 'sn':[],
-                'enum':['a','b','d'],
-                'mail':['michael@stroeder.com'],
+                'enum':[b'a',b'b',b'd'],
+                'mail':[b'michael@stroeder.com'],
             },
             [],
             [
                 (ldap.MOD_DELETE,'objectClass',None),
-                (ldap.MOD_ADD,'objectClass',['person','inetOrgPerson']),
+                (ldap.MOD_ADD,'objectClass',[b'person',b'inetOrgPerson']),
                 (ldap.MOD_DELETE,'c',None),
                 (ldap.MOD_DELETE,'sn',None),
-                (ldap.MOD_ADD,'mail',['michael@stroeder.com']),
+                (ldap.MOD_ADD,'mail',[b'michael@stroeder.com']),
                 (ldap.MOD_DELETE,'enum',None),
-                (ldap.MOD_ADD,'enum',['a','b','d']),
+                (ldap.MOD_ADD,'enum',[b'a',b'b',b'd']),
             ]
         ),
 
         (
             {
-                'c':['DE'],
+                'c':[b'DE'],
             },
             {
-                'c':['FR'],
+                'c':[b'FR'],
             },
             [],
             [
                 (ldap.MOD_DELETE,'c',None),
-                (ldap.MOD_ADD,'c',['FR']),
+                (ldap.MOD_ADD,'c',[b'FR']),
             ]
         ),
 
@@ -95,10 +95,10 @@ class TestModlist(unittest.TestCase):
         # of removing an attribute with MOD_DELETE,attr_type,None
         (
             {
-                'objectClass':['person'],
+                'objectClass':[b'person'],
                 'cn':[None],
-                'sn':[''],
-                'c':['DE'],
+                'sn':[b''],
+                'c':[b'DE'],
             },
             {
                 'objectClass':[],
@@ -115,22 +115,22 @@ class TestModlist(unittest.TestCase):
 
         (
             {
-                'objectClass':['person'],
-                'cn':['Michael Str\303\266der','Michael Stroeder'],
-                'sn':['Str\303\266der'],
-                'enum':['a','b','C'],
+                'objectClass':[b'person'],
+                'cn':[b'Michael Str\303\266der',b'Michael Stroeder'],
+                'sn':[b'Str\303\266der'],
+                'enum':[b'a',b'b',b'C'],
             },
             {
-                'objectClass':['Person'],
-                'cn':['Michael Str\303\266der','Michael Stroeder'],
+                'objectClass':[b'Person'],
+                'cn':[b'Michael Str\303\266der',b'Michael Stroeder'],
                 'sn':[],
-                'enum':['a','b','c'],
+                'enum':[b'a',b'b',b'c'],
             },
             ['objectClass'],
             [
                 (ldap.MOD_DELETE,'sn',None),
                 (ldap.MOD_DELETE,'enum',None),
-                (ldap.MOD_ADD,'enum',['a','b','c']),
+                (ldap.MOD_ADD,'enum',[b'a',b'b',b'c']),
             ]
         ),
 


### PR DESCRIPTION
The `modlists` variable in the code below is an return value of `ldap.modlist.addModlist()` expected by the tests in Tests/t_ldap_modlist.py, exactly extracted from the `test_addmodlist` case in the file (https://github.com/python-ldap/python-ldap/blob/master/Tests/t_ldap_modlist.py#L22-L29 ).
`add_ext_s()` with it raises `TypeError` on Python 3 though (Traceback is below).

This PR fixes tests in Tests/t_ldap_modlist.py .

Code:

```python
#!/usr/bin/env python3
import ldap
import ldap.modlist

URI = "ldaps://localhost:1636"
ADMIN_DN = "cn=admin,dc=example,dc=com"
ADMIN_PASSWORD = "secret"

def ldap_add_string_list(lo, dn):

    modlists = [
        ('objectClass',['person','pilotPerson']),
        ('cn',['Michael Str\303\266der','Michael Stroeder']),
        ('sn',['Str\303\266der']),
        ('dummy2',['2']),
        ('dummy3',['']),
    ]

    lo.add_ext_s(dn, modlists)


def get_ldap_object(uri):
    lo = ldap.ldapobject.LDAPObject(uri)
    lo.bind_s(ADMIN_DN, ADMIN_PASSWORD)

    lo.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
    lo.set_option(ldap.OPT_X_TLS_NEWCTX, 0)

    return lo


if __name__ == '__main__':
    dn = "uid=test,dc=example,dc=com"

    lo = get_ldap_object(URI)
    ldap_add_string_list(lo, dn)
```

Traceback:

```python
Traceback (most recent call last):
  File "addmodlist.py", line 36, in <module>
    ldap_add_string_list(lo, dn)
  File "addmodlist.py", line 19, in ldap_add_string_list
    lo.add_ext_s(dn, modlists)
  File "/tmp/venv/lib/python3.5/site-packages/ldap/ldapobject.py", line 413, in add_ext_s
    msgid = self.add_ext(dn,modlist,serverctrls,clientctrls)
  File "/tmp/venv/lib/python3.5/site-packages/ldap/ldapobject.py", line 410, in add_ext
    return self._ldap_call(self._l.add_ext,dn,modlist,RequestControlTuples(serverctrls),RequestControlTuples(clientctrls))
  File "/tmp/venv/lib/python3.5/site-packages/ldap/ldapobject.py", line 313, in _ldap_call
    result = func(*args,**kwargs)
TypeError: ('Tuple_to_LDAPMod(): expected a byte string in the list', 'person')
```
