### PR TITLE
Drop u prefix from literals in files that import unicode_literals

### DIFF
--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -260,7 +260,7 @@ class SimpleLDAPObject:
     else:
       # It's a list of referals
       # Example value:
-      # [u'ldap://DomainDnsZones.xxxx.root.local/DC=DomainDnsZones,DC=xxxx,DC=root,DC=local']
+      # ['ldap://DomainDnsZones.xxxx.root.local/DC=DomainDnsZones,DC=xxxx,DC=root,DC=local']
       return [self._maybe_rebytesify_text(referal) for referal in result_value]
 
   def _bytesify_results(self, results, with_ctrls=False):
@@ -823,7 +823,7 @@ class SimpleLDAPObject:
           if self.bytes_mode:
             filterstr = b'(objectClass=*)'
           else:
-            filterstr = u'(objectClass=*)'
+            filterstr = '(objectClass=*)'
         else:
           filterstr = self._bytesify_input('filterstr', filterstr)
         if attrlist is not None:
@@ -932,8 +932,8 @@ class SimpleLDAPObject:
       empty_dn = b''
       attrname = b'subschemaSubentry'
     else:
-      empty_dn = u''
-      attrname = u'subschemaSubentry'
+      empty_dn = ''
+      attrname = 'subschemaSubentry'
     if dn is None:
       dn = empty_dn
     try:
@@ -991,7 +991,7 @@ class SimpleLDAPObject:
       if attrs is None:
         attrs = [attr.encode('utf-8') for attr in SCHEMA_ATTRS]
     else:
-      filterstr = u'(objectClass=subschema)'
+      filterstr = '(objectClass=subschema)'
       if attrs is None:
         attrs = SCHEMA_ATTRS
     try:
@@ -1032,8 +1032,8 @@ class SimpleLDAPObject:
       base = b''
       attrlist = attrlist or [b'*', b'+']
     else:
-      base = u''
-      attrlist = attrlist or [u'*', u'+']
+      base = ''
+      attrlist = attrlist or ['*', '+']
     ldap_rootdse = self.read_s(
       base,
       filterstr=filterstr,
@@ -1049,7 +1049,7 @@ class SimpleLDAPObject:
     if self.bytes_mode:
       name = b'namingContexts'
     else:
-      name = u'namingContexts'
+      name = 'namingContexts'
     return self.read_rootdse_s(
       attrlist=[name]
     ).get(name, [])

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -112,7 +112,7 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
             )
         if PY2:
             self.assertIn(
-                u"got type 'str' for 'base'", text_type(e.exception)
+                "got type 'str' for 'base'", text_type(e.exception)
             )
         elif sys.version_info >= (3, 5, 0):
             # Python 3.4.x does not include 'search_ext()' in message
@@ -127,7 +127,7 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
             )
         if PY2:
             self.assertIn(
-                u"got type 'str' for 'filterstr'", text_type(e.exception)
+                "got type 'str' for 'filterstr'", text_type(e.exception)
             )
         elif sys.version_info >= (3, 5, 0):
             self.assertEqual(
@@ -141,7 +141,7 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
             )
         if PY2:
             self.assertIn(
-                u"got type 'str' for 'attrlist'", text_type(e.exception)
+                "got type 'str' for 'attrlist'", text_type(e.exception)
             )
         elif sys.version_info >= (3, 5, 0):
             self.assertEqual(
@@ -424,11 +424,11 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
         self.assertEqual(
             sorted(subschema),
             [
-                u'attributeTypes',
-                u'ldapSyntaxes',
-                u'matchingRuleUse',
-                u'matchingRules',
-                u'objectClasses'
+                'attributeTypes',
+                'ldapSyntaxes',
+                'matchingRuleUse',
+                'matchingRules',
+                'objectClasses'
             ]
         )
 
@@ -504,10 +504,10 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
     def test_simple_bind_noarg(self):
         l = self.ldap_object_class(self.server.ldap_uri)
         l.simple_bind_s()
-        self.assertEqual(l.whoami_s(), u'')
+        self.assertEqual(l.whoami_s(), '')
         l = self.ldap_object_class(self.server.ldap_uri)
         l.simple_bind_s(None, None)
-        self.assertEqual(l.whoami_s(), u'')
+        self.assertEqual(l.whoami_s(), '')
 
     @unittest.skipUnless(PY2, "no bytes_mode under Py3")
     def test_ldapbyteswarning(self):
@@ -578,10 +578,10 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
         self.assertEqual(len(w), 2, w)
 
         self._check_byteswarning(
-            w[0], u"Received non-bytes value for 'filterstr'")
+            w[0], "Received non-bytes value for 'filterstr'")
 
         self._check_byteswarning(
-            w[1], u"Received non-bytes value for 'attrlist'")
+            w[1], "Received non-bytes value for 'attrlist'")
 
     @unittest.skipUnless(PY2, "no bytes_mode under Py3")
     def test_byteswarning_level_search(self):
@@ -600,7 +600,7 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
         self.assertEqual(len(w), 1, w)
 
         self._check_byteswarning(
-            w[0], u"Under Python 2, python-ldap uses bytes by default.")
+            w[0], "Under Python 2, python-ldap uses bytes by default.")
 
     @requires_tls()
     def test_multiple_starttls(self):
@@ -619,16 +619,16 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
     def test_dse(self):
         dse = self._ldap_conn.read_rootdse_s()
         self.assertIsInstance(dse, dict)
-        self.assertEqual(dse[u'supportedLDAPVersion'], [b'3'])
+        self.assertEqual(dse['supportedLDAPVersion'], [b'3'])
         keys = set(dse)
         # SASL info may be missing in restricted build environments
-        keys.discard(u'supportedSASLMechanisms')
+        keys.discard('supportedSASLMechanisms')
         self.assertEqual(
             keys,
-            {u'configContext', u'entryDN', u'namingContexts', u'objectClass',
-             u'structuralObjectClass', u'subschemaSubentry',
-             u'supportedControl', u'supportedExtension', u'supportedFeatures',
-             u'supportedLDAPVersion'}
+            {'configContext', 'entryDN', 'namingContexts', 'objectClass',
+             'structuralObjectClass', 'subschemaSubentry',
+             'supportedControl', 'supportedExtension', 'supportedFeatures',
+             'supportedLDAPVersion'}
         )
         self.assertEqual(
             self._ldap_conn.get_naming_contexts(),
@@ -640,7 +640,7 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
         l = self._get_bytes_ldapobject()
         dse = l.read_rootdse_s()
         self.assertIsInstance(dse, dict)
-        self.assertEqual(dse[u'supportedLDAPVersion'], [b'3'])
+        self.assertEqual(dse['supportedLDAPVersion'], [b'3'])
         self.assertEqual(
             l.get_naming_contexts(),
             [self.server.suffix.encode('utf-8')]


### PR DESCRIPTION
For files that have `from __future__ import unicode_literals`, the u prefix is unnecessary. String literals without a prefix are already Unicode literals. By dropping the prefix, uses a modern Python3 syntax style.