### PR TITLE
Fix assertTrue(result, _ldap.RES_BIND) to assertEqual()

### DIFF
--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -234,7 +234,7 @@ class TestLdapCExtension(SlapdTestCase):
         m = l.simple_bind("", "")
         self.assertEqual(type(m), type(0))
         result, pmsg, msgid, ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertTrue(result, _ldap.RES_BIND)
+        self.assertEqual(result, _ldap.RES_BIND)
         self.assertEqual(msgid, m)
         self.assertEqual(pmsg, [])
         self.assertEqual(ctrls, [])
@@ -629,7 +629,7 @@ class TestLdapCExtension(SlapdTestCase):
         # Anonymous bind
         m = l.simple_bind("", "")
         result, pmsg, msgid, ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)
-        self.assertTrue(result, _ldap.RES_BIND)
+        self.assertEqual(result, _ldap.RES_BIND)
         # check with Who Am I? extended operation
         r = l.whoami_s()
         self.assertEqual("", r)


### PR DESCRIPTION
Fix a pattern where `assertTrue(result, _ldap.RES_BIND)` was mistakenly used in place of `self.assertEqual(result, _ldap.RES_BIND)`.

Mistakes introduced in commit 162cedf71ba62b3944d18a27ed206d55e679f966.