### PR TITLE
Return a bool in .compare_s() and .compare_ext_s()

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,11 @@
 ----------------------------------------------------------------
+UNRELEASED
+
+Lib/
+* LDAPObject.compare_s() and LDAPObject.compare_ext_s() now return a bool
+  instead of 1 or 0.
+
+----------------------------------------------------------------
 Released 3.0.0 2018-03-12
 
 Notable changes since 2.4.45 (please see detailed logs below):

--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -704,17 +704,16 @@ and wait for and return with the server's result, or with
 
 .. py:method:: LDAPObject.compare(dn, attr, value) -> int
 
-.. py:method:: LDAPObject.compare_s(dn, attr, value) -> tuple
+.. py:method:: LDAPObject.compare_s(dn, attr, value) -> bool
 
 .. py:method:: LDAPObject.compare_ext(dn, attr, value [, serverctrls=None [, clientctrls=None]]) -> int
 
-.. py:method:: LDAPObject.compare_ext_s(dn, attr, value [, serverctrls=None [, clientctrls=None]]) -> tuple
+.. py:method:: LDAPObject.compare_ext_s(dn, attr, value [, serverctrls=None [, clientctrls=None]]) -> bool
 
-   Perform an LDAP comparison between the attribute named *attr* of
-   entry *dn*, and the value *value*. The synchronous forms
-   returns :py:const:`0` for false, or :py:const:`1` for true.
-   The asynchronous forms returns the message ID of the initiated request,
-   and the result of the asynchronous compare can be obtained using
+   Perform an LDAP comparison between the attribute named *attr* of entry *dn*,
+   and the value *value*. The synchronous forms returns ``True`` or ``False``.
+   The asynchronous forms returns the message ID of the initiated request, and
+   the result of the asynchronous compare can be obtained using
    :py:meth:`result()`.
 
    Note that the asynchronous technique yields the answer

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -495,14 +495,14 @@ class SimpleLDAPObject:
   def compare_ext(self,dn,attr,value,serverctrls=None,clientctrls=None):
     """
     compare_ext(dn, attr, value [,serverctrls=None[,clientctrls=None]]) -> int
-    compare_ext_s(dn, attr, value [,serverctrls=None[,clientctrls=None]]) -> int
+    compare_ext_s(dn, attr, value [,serverctrls=None[,clientctrls=None]]) -> bool
     compare(dn, attr, value) -> int
-    compare_s(dn, attr, value) -> int
-        Perform an LDAP comparison between the attribute named attr of
-        entry dn, and the value value. The synchronous form returns 0
-        for false, or 1 for true.  The asynchronous form returns the
-        message id of the initiates request, and the result of the
-        asynchronous compare can be obtained using result().
+    compare_s(dn, attr, value) -> bool
+        Perform an LDAP comparison between the attribute named attr of entry
+        dn, and the value value. The synchronous form returns True or False.
+        The asynchronous form returns the message id of the initiates request,
+        and the result of the asynchronous compare can be obtained using
+        result().
 
         Note that this latter technique yields the answer by raising
         the exception objects COMPARE_TRUE or COMPARE_FALSE.
@@ -520,9 +520,9 @@ class SimpleLDAPObject:
     try:
         ldap_res = self.result3(msgid,all=1,timeout=self.timeout)
     except ldap.COMPARE_TRUE:
-      return 1
+      return True
     except ldap.COMPARE_FALSE:
-      return 0
+      return False
     raise ldap.PROTOCOL_ERROR(
         'Compare operation returned wrong result: %r' % (ldap_res)
     )

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -646,6 +646,18 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
             [self.server.suffix.encode('utf-8')]
         )
 
+    def test_compare_s_true(self):
+        base = self.server.suffix
+        l = self._ldap_conn
+        result = l.compare_s('cn=Foo1,%s' % base, 'cn', 'Foo1')
+        self.assertIs(result, True)
+
+    def test_compare_s_false(self):
+        base = self.server.suffix
+        l = self._ldap_conn
+        result = l.compare_s('cn=Foo1,%s' % base, 'cn', 'Foo2')
+        self.assertIs(result, False)
+
 
 class Test01_ReconnectLDAPObject(Test00_SimpleLDAPObject):
     """


### PR DESCRIPTION
Previously, `LDAPObject.compare_s()` and `LDAPObject.compare_ext_s()` returned 1 for true and 0 for false. As the return value is intended for a `bool` context, return a `bool` instead.