### PR TITLE
Fix ref counting bug in LDAPmessage_to_python

### DIFF
--- a/Modules/message.c
+++ b/Modules/message.c
@@ -99,7 +99,15 @@ LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls,
 
             /* Find which list to append to */
             if (PyDict_Contains(attrdict, pyattr)) {
+                /* Multiple attribute entries with same name. This code path
+                 * is rarely used and cannot be exhausted with OpenLDAP
+                 * tests. 389-DS sometimes triggeres it, see
+                 * https://github.com/python-ldap/python-ldap/issues/218
+                 */
                 valuelist = PyDict_GetItem(attrdict, pyattr);
+                /* Turn borrowed reference into owned reference */
+                if (valuelist != NULL)
+                    Py_INCREF(valuelist);
             }
             else {
                 valuelist = PyList_New(0);


### PR DESCRIPTION
PyDict_GetItem() returns a borrowed reference. The code later
Py_DECREF() the reference, which causes a segfault at a later point in
time.

Fixes: https://github.com/python-ldap/python-ldap/issues/218
Signed-off-by: Christian Heimes <cheimes@redhat.com>