### PR TITLE
filter out None from attribute values at modlist.addModlist()

### DIFF
--- a/Lib/ldap/modlist.py
+++ b/Lib/ldap/modlist.py
@@ -20,7 +20,7 @@ def addModlist(entry,ignore_attr_types=None):
     # Eliminate empty attr value strings in list
     attrvaluelist = [item for item in value if item is not None]
     if attrvaluelist:
-      modlist.append((attrtype, value))
+      modlist.append((attrtype, attrvaluelist))
   return modlist # addModlist()
 
 

--- a/Lib/ldap/modlist.py
+++ b/Lib/ldap/modlist.py
@@ -9,7 +9,7 @@ from ldap import __version__
 import ldap
 
 
-def addModlist(entry,ignore_attr_types=None):
+def addModlist(entry, ignore_attr_types=None):
   """Build modify list for call of method LDAPObject.add()"""
   ignore_attr_types = {v.lower() for v in ignore_attr_types or []}
   modlist = []
@@ -17,11 +17,14 @@ def addModlist(entry,ignore_attr_types=None):
     if attrtype.lower() in ignore_attr_types:
       # This attribute type is ignored
       continue
-    # Eliminate empty attr value strings in list
-    attrvaluelist = [item for item in value if item is not None]
-    if attrvaluelist:
-      modlist.append((attrtype, attrvaluelist))
-  return modlist # addModlist()
+    if isinstance(value, bytes):
+      modlist.append((attrtype, value))
+    else:
+      # Eliminate empty attr value strings in list
+      attrvaluelist = [item for item in value if item is not None]
+      if attrvaluelist:
+        modlist.append((attrtype, attrvaluelist))
+  return modlist  # addModlist()
 
 
 def modifyModlist(

--- a/Tests/t_ldap_modlist.py
+++ b/Tests/t_ldap_modlist.py
@@ -35,6 +35,14 @@ class TestModlist(unittest.TestCase):
                 ('dummy3',[b'']),
             ]
         ),
+        (
+            {
+                'cn': [None, b'Michael Stroeder']
+            },
+            [
+                ('cn', [b'Michael Stroeder'])
+            ]
+        )
     ]
 
     def test_addModlist(self):

--- a/Tests/t_ldap_modlist.py
+++ b/Tests/t_ldap_modlist.py
@@ -42,6 +42,14 @@ class TestModlist(unittest.TestCase):
             [
                 ('cn', [b'Michael Stroeder'])
             ]
+        ),
+        (
+            {
+                'cn': b'Michael Stroeder'
+            },
+            [
+                ('cn', b'Michael Stroeder')
+            ]
         )
     ]
 


### PR DESCRIPTION
Obviously a bug (unused variable and inconsistent behaviour with `modifyModlist()`).
Fix with a test.