### PR TITLE
tests: Use system-specific ENOTCONN value

### DIFF
--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -7,6 +7,7 @@ See https://www.python-ldap.org/ for details.
 
 from __future__ import unicode_literals
 
+import errno
 import os
 import unittest
 
@@ -731,15 +732,16 @@ class TestLdapCExtension(SlapdTestCase):
         if not self._require_attr(l, 'cancel'):         # FEATURE_CANCEL
             return
 
-    def test_errno107(self):
+    def test_enotconn(self):
         l = _ldap.initialize('ldap://127.0.0.1:42')
         try:
             m = l.simple_bind("", "")
             r = l.result4(m, _ldap.MSG_ALL, self.timeout)
         except _ldap.SERVER_DOWN as ldap_err:
-            errno = ldap_err.args[0]['errno']
-            if errno != 107:
-                self.fail("expected errno=107, got %d" % errno)
+            errno_val = ldap_err.args[0]['errno']
+            if errno_val != errno.ENOTCONN:
+                self.fail("expected errno=%d, got %d"
+                          % (errno.ENOTCONN, errno_val))
         else:
             self.fail("expected SERVER_DOWN, got %r" % r)
 

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -16,6 +16,7 @@ else:
     PY2 = False
     text_type = str
 
+import errno
 import contextlib
 import linecache
 import os
@@ -451,18 +452,20 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
             ]
         )
 
-    def test004_errno107(self):
+    def test004_enotconn(self):
         l = self.ldap_object_class('ldap://127.0.0.1:42')
         try:
             m = l.simple_bind_s("", "")
             r = l.result4(m, ldap.MSG_ALL, self.timeout)
         except ldap.SERVER_DOWN as ldap_err:
-            errno = ldap_err.args[0]['errno']
-            if errno != 107:
-                self.fail("expected errno=107, got %d" % errno)
+            errno_val = ldap_err.args[0]['errno']
+            if errno_val != errno.ENOTCONN:
+                self.fail("expected errno=%d, got %d"
+                          % (errno.ENOTCONN, errno_val))
             info = ldap_err.args[0]['info']
-            if info != os.strerror(107):
-                self.fail("expected info=%r, got %d" % (os.strerror(107), info))
+            expected_info = os.strerror(errno.ENOTCONN)
+            if info != expected_info:
+                self.fail("expected info=%r, got %d" % (expected_info, info))
         else:
             self.fail("expected SERVER_DOWN, got %r" % r)
 


### PR DESCRIPTION
The integer values for `errno` are  not standard and can vary from
platform to platform, so the tests should rely on the constants
provided in `errno` module.

Closes: #228