### PR TITLE
Lib/ldap: Provide _trace_level and _trace_file in non-debug mode

### DIFF
--- a/Lib/ldap/__init__.py
+++ b/Lib/ldap/__init__.py
@@ -23,6 +23,13 @@ if __debug__:
     _trace_file = open(_trace_file, 'a')
     atexit.register(_trace_file.close)
   _trace_stack_limit = None
+else:
+  # Any use of the _trace attributes should be guarded by `if __debug__`,
+  # so they should not be needed here.
+  # But, providing different API for debug mode is unnecessarily fragile.
+  _trace_level = 0
+  _trace_file = sys.stderr
+  _trace_stack_limit = None
 
 import _ldap
 assert _ldap.__version__==__version__, \


### PR DESCRIPTION
All use of these attributes *should* be guarded by `if __debug__`.
However, that's not always the case. Providing different API based
on `__debug__` is unnecessarily fragile.

This is intended as a quick fix for a maintenance release (3.1.1). More coming up in another PR.

Fixes: https://github.com/python-ldap/python-ldap/issues/226