### PR TITLE
Add Python 3.8-dev to Tox config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,13 @@ matrix:
         - WITH_GCOV=1
       dist: xenial
       sudo: true
+    - python: 3.8-dev
+      env:
+        - TOXENV=py38
+        - CFLAGS_std="-std=c99"
+        - WITH_GCOV=1
+      dist: xenial
+      sudo: true
     - python: 2.7
       env:
         - TOXENV=py2-nosasltls
@@ -54,6 +61,10 @@ matrix:
       env: TOXENV=doc
   allow_failures:
      - env:
+        - TOXENV=py38
+        - CFLAGS_std="-std=c99"
+        - WITH_GCOV=1
+     - env:
         - TOXENV=pypy
 
 env:
@@ -61,7 +72,10 @@ env:
         # -Wno-int-in-bool-context: don't complain about PyMem_MALLOC()
         # -Werror: turn all warnings into fatal errors
         # -Werror=declaration-after-statement: strict ISO C90
-        - CFLAGS="-std=c90 -Wno-int-in-bool-context -Werror -Werror=declaration-after-statement"
+        - CFLAGS_warnings="-Wno-int-in-bool-context -Werror -Werror=declaration-after-statement"
+        # Keep C90 compatibility where possible.
+        # (Python 3.8+ headers use C99 features, so this needs to be overridable.)
+        - CFLAGS_std="-std=c90"
         # pass CFLAGS, CI (for Travis CI) and WITH_GCOV to tox tasks
         - TOX_TESTENV_PASSENV="CFLAGS CI WITH_GCOV"
 
@@ -69,7 +83,7 @@ install:
   - pip install "pip>=7.1.0"
   - pip install tox-travis tox codecov coverage
 
-script: tox
+script: CFLAGS="$CFLAGS_warnings $CFLAGS_std" tox
 
 after_success:
   # gather Python coverage

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # Note: when updating Python versions, also change setup.py and .travis.yml
-envlist = py27,py34,py35,py36,py37,{py2,py3}-nosasltls,doc,py3-trace,coverage-report
+envlist = py27,py34,py35,py36,py37,py38,{py2,py3}-nosasltls,doc,py3-trace,coverage-report
 minver = 1.8
 
 [testenv]


### PR DESCRIPTION
Let's catch issues early – both in python-ldap and CPython.

With all relevant compilers supporting C99, Python 3.6+ makes use of [some C99 features](https://www.python.org/dev/peps/pep-0007/#c-dialect), and in 3.8-dev `//` comments found their way to headers included from `Python.h`.
I'd like to keep checking C90 compat for older Python versions, hence a bit of indirection to set the -std flag.