### PR TITLE
Attach response controls to exceptions

### DIFF
--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -316,6 +316,7 @@ The module defines the following exceptions:
    is set to a truncated form of the name provided or alias dereferenced
    for the lowest entry (object or alias) that was matched.
 
+   The :py:const:`ctrls` field can be included to the dictionary, which is a list of response controls.
 
 .. py:exception:: ADMINLIMIT_EXCEEDED
 

--- a/Doc/reference/slapdtest.rst
+++ b/Doc/reference/slapdtest.rst
@@ -27,8 +27,3 @@ Classes
 .. autoclass:: slapdtest.SlapdTestCase
    :members:
 
-.. autoclass:: slapdtest.PPolicyEnabledSlapdObject
-   :members:
-
-.. autoclass:: slapdtest.PPolicyEnabledSlapdTestCase
-   :members:

--- a/Doc/reference/slapdtest.rst
+++ b/Doc/reference/slapdtest.rst
@@ -26,3 +26,9 @@ Classes
 
 .. autoclass:: slapdtest.SlapdTestCase
    :members:
+
+.. autoclass:: slapdtest.PPolicyEnabledSlapdObject
+   :members:
+
+.. autoclass:: slapdtest.PPolicyEnabledSlapdTestCase
+   :members:

--- a/Lib/slapdtest/__init__.py
+++ b/Lib/slapdtest/__init__.py
@@ -9,7 +9,7 @@ __version__ = '3.1.0'
 
 from slapdtest._slapdtest import (
     SlapdObject, SlapdTestCase,
-    PPolicyEnabledSlapdObject, PPolicyEnabledSlapdTestCase,
+    PPolicyEnabledSlapdObject,
     SysLogHandler)
 from slapdtest._slapdtest import requires_ldapi, requires_sasl, requires_tls
 from slapdtest._slapdtest import skip_unless_ci

--- a/Lib/slapdtest/__init__.py
+++ b/Lib/slapdtest/__init__.py
@@ -7,6 +7,9 @@ See https://www.python-ldap.org/ for details.
 
 __version__ = '3.1.0'
 
-from slapdtest._slapdtest import SlapdObject, SlapdTestCase, SysLogHandler
+from slapdtest._slapdtest import (
+    SlapdObject, SlapdTestCase,
+    PPolicyEnabledSlapdObject, PPolicyEnabledSlapdTestCase,
+    SysLogHandler)
 from slapdtest._slapdtest import requires_ldapi, requires_sasl, requires_tls
 from slapdtest._slapdtest import skip_unless_ci

--- a/Lib/slapdtest/__init__.py
+++ b/Lib/slapdtest/__init__.py
@@ -7,9 +7,6 @@ See https://www.python-ldap.org/ for details.
 
 __version__ = '3.1.0'
 
-from slapdtest._slapdtest import (
-    SlapdObject, SlapdTestCase,
-    PPolicyEnabledSlapdObject,
-    SysLogHandler)
+from slapdtest._slapdtest import SlapdObject, SlapdTestCase, SysLogHandler
 from slapdtest._slapdtest import requires_ldapi, requires_sasl, requires_tls
 from slapdtest._slapdtest import skip_unless_ci

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -654,12 +654,3 @@ class PPolicyEnabledSlapdObject(SlapdObject):
                 'ppolicy_use_lockout'])
         },
     )
-
-
-class PPolicyEnabledSlapdTestCase(SlapdTestCase):
-    """
-    A subclass of :py:class:`SlapdTestCase`, which uses
-    :py:class:`PPolicyEnabledSlapdObject` as the slapd controller.
-    """
-
-    server_class = PPolicyEnabledSlapdObject

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -623,34 +623,3 @@ class SlapdTestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.server.stop()
-
-
-class PPolicyEnabledSlapdObject(SlapdObject):
-    """
-    A subclass of :py:class:`SlapdObject` with password policy enabled.
-    Note that this class has no actual password policy configuration entries.
-    It is the job of the users of this class to define
-    the default password policies on their own.
-    The dn of the default is :attr:`.default_ppolicy_dn` of this class.
-    """
-
-    openldap_schema_files = (
-        'core.schema', 'ppolicy.schema'
-    )
-    modules = (
-        'ppolicy',
-    )
-
-    default_ppolicy_dn = "cn=default-ppolicy,%(suffix)s" % {
-        'suffix': SlapdObject.suffix
-    }
-
-    overlays = (
-        {
-            'name': 'ppolicy',
-            'configuration': "\n".join([
-                'ppolicy_default "{}"'.format(default_ppolicy_dn),
-                # let slapd tell the clients that they are locked out
-                'ppolicy_use_lockout'])
-        },
-    )

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -612,17 +612,10 @@ class SlapdTestCase(unittest.TestCase):
         """
         return a LDAPObject instance after simple bind
         """
-        ldap_conn = self._make_ldap_object(**kwargs)
-        ldap_conn.simple_bind_s(who or self.server.root_dn, cred or self.server.root_pw)
-        return ldap_conn
-
-    def _make_ldap_object(self, **kwargs):
-        """
-        return an unbound LDAPObject instance with common ldap options.
-        """
         ldap_conn = self.ldap_object_class(self.server.ldap_uri, **kwargs)
         ldap_conn.protocol_version = 3
-        # ldap_conn.set_option(ldap.OPT_REFERRALS, 0)
+        #ldap_conn.set_option(ldap.OPT_REFERRALS, 0)
+        ldap_conn.simple_bind_s(who or self.server.root_dn, cred or self.server.root_pw)
         return ldap_conn
 
     @classmethod

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -191,7 +191,17 @@ class SlapdObject(object):
         'core.schema',
     )
 
+    #: List (or tuple) of OpenLDAP module names you want to activate.
+    #: Default is empty.
     modules = ()
+
+    #: List (or tuple) of OpenLDAP overlay settings you want to include.
+    #: Default is empty.
+    #: Each element is a dict of the form of::
+    #:
+    #:     {"name": overlay_name,
+    #:      "configuration": configuration_text}
+    #:
     overlays = ()
 
     TMPDIR = os.environ.get('TMP', os.getcwd())

--- a/Modules/constants.c
+++ b/Modules/constants.c
@@ -106,7 +106,6 @@ LDAPraise_exception(LDAP *l, char *msg, PyObject *pyctrls)
 
         if (pyctrls != NULL) {
             PyDict_SetItemString(info, "ctrls", pyctrls);
-            /* Py_XDECREF(pyctrls) must be called on caller side */
         }
 
         if (errnum == LDAP_REFERRAL) {

--- a/Modules/constants.h
+++ b/Modules/constants.h
@@ -12,6 +12,7 @@ extern PyObject *LDAPconstant(int);
 
 extern PyObject *LDAPexception_class;
 extern PyObject *LDAPerror(LDAP *, char *msg);
+extern PyObject *LDAPraise_exception(LDAP *, char *msg, PyObject *pyctrls);
 PyObject *LDAPerr(int errnum);
 
 #ifndef LDAP_CONTROL_PAGE_OID

--- a/Tests/t_ldap_controls_ppolicy.py
+++ b/Tests/t_ldap_controls_ppolicy.py
@@ -9,6 +9,7 @@ from ldap.controls import ppolicy
 
 PP_GRACEAUTH = b'0\x84\x00\x00\x00\t\xa0\x84\x00\x00\x00\x03\x81\x01\x02'
 PP_TIMEBEFORE = b'0\x84\x00\x00\x00\t\xa0\x84\x00\x00\x00\x03\x80\x012'
+PP_ACCOUNT_LOCKOUT = b'0\x03\x81\x01\x01'
 
 
 class TestControlsPPolicy(unittest.TestCase):
@@ -27,6 +28,11 @@ class TestControlsPPolicy(unittest.TestCase):
         pp = ppolicy.PasswordPolicyControl()
         pp.decodeControlValue(PP_TIMEBEFORE)
         self.assertPPolicy(pp, timeBeforeExpiration=50)
+
+    def test_ppolicy_account_lockout(self):
+        pp = ppolicy.PasswordPolicyControl()
+        pp.decodeControlValue(PP_ACCOUNT_LOCKOUT)
+        self.assertPPolicy(pp, error=1)
 
 
 if __name__ == '__main__':

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -170,8 +170,11 @@ userPassword: {password}'''.format(cn=cn, dn=user_dn, password=password)
                 serverctrls=[ldap.controls.ppolicy.PasswordPolicyControl()])
 
         controls = cm.exception.args[0]['ctrls']
-        pp = ldap.controls.DecodeControlTuples(controls)[0]
-        self.assertEqual(pp.error, 1)  # error == 1 means AccountLockout
+        decoded_controls = ldap.controls.DecodeControlTuples(controls)
+        self.assertEqual(len(decoded_controls), 1)
+        pp = decoded_controls[0]
+        expected_error = ldap.controls.ppolicy.PasswordPolicyError('accountLocked')
+        self.assertEqual(pp.error, int(expected_error))
 
 
 class Test00_SimpleLDAPObject(SlapdTestCase):

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -31,7 +31,7 @@ import ldap
 import ldap.controls
 import ldap.controls.ppolicy
 from ldap.ldapobject import SimpleLDAPObject, ReconnectLDAPObject
-from slapdtest import SlapdTestCase, PPolicyEnabledSlapdObject
+from slapdtest import SlapdTestCase, SlapdObject
 from slapdtest import requires_ldapi, requires_sasl, requires_tls
 
 
@@ -74,6 +74,37 @@ objectClass: organizationalRole
 cn: Foo4
 
 """
+
+
+class PPolicyEnabledSlapdObject(SlapdObject):
+    """
+    A subclass of :py:class:`SlapdObject` with password policy enabled.
+    Note that this class has no actual password policy configuration entries.
+    It is the job of the users of this class to define
+    the default password policies on their own.
+    The dn of the default is :attr:`.default_ppolicy_dn` of this class.
+    """
+
+    openldap_schema_files = (
+        'core.schema', 'ppolicy.schema'
+    )
+    modules = (
+        'ppolicy',
+    )
+
+    default_ppolicy_dn = "cn=default-ppolicy,%(suffix)s" % {
+        'suffix': SlapdObject.suffix
+    }
+
+    overlays = (
+        {
+            'name': 'ppolicy',
+            'configuration': "\n".join([
+                'ppolicy_default "{}"'.format(default_ppolicy_dn),
+                # let slapd tell the clients that they are locked out
+                'ppolicy_use_lockout'])
+        },
+    )
 
 
 class Test02_ResponseControl(SlapdTestCase):

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -157,7 +157,7 @@ cn: {cn}
 userPassword: {password}'''.format(cn=cn, dn=user_dn, password=password)
         )
 
-        ldap_conn = self._make_ldap_object(bytes_mode=False)
+        ldap_conn = self.ldap_object_class(self.server.ldap_uri)
 
         # Firstly cause a bind failure to lock out the account
         with self.assertRaises(ldap.INVALID_CREDENTIALS):

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -160,9 +160,12 @@ userPassword: {password}'''.format(cn=cn, dn=user_dn, password=password)
         ldap_conn = self.ldap_object_class(self.server.ldap_uri)
 
         # Firstly cause a bind failure to lock out the account
-        with self.assertRaises(ldap.INVALID_CREDENTIALS):
+        with self.assertRaises(ldap.INVALID_CREDENTIALS) as cm:
             wrong_password = 'wrong' + password
             ldap_conn.simple_bind_s(user_dn, wrong_password)
+
+        empty_controls = cm.exception.args[0]['ctrls']
+        self.assertEqual(len(empty_controls), 0)
 
         with self.assertRaises(ldap.INVALID_CREDENTIALS) as cm:
             ldap_conn.simple_bind_s(

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -31,7 +31,7 @@ import ldap
 import ldap.controls
 import ldap.controls.ppolicy
 from ldap.ldapobject import SimpleLDAPObject, ReconnectLDAPObject
-from slapdtest import SlapdTestCase, PPolicyEnabledSlapdTestCase
+from slapdtest import SlapdTestCase, PPolicyEnabledSlapdObject
 from slapdtest import requires_ldapi, requires_sasl, requires_tls
 
 
@@ -76,12 +76,13 @@ cn: Foo4
 """
 
 
-class Test02_ResponseControl(PPolicyEnabledSlapdTestCase):
+class Test02_ResponseControl(SlapdTestCase):
     """
     tests abount response controls sent by the server
     """
 
     ldap_object_class = SimpleLDAPObject
+    server_class = PPolicyEnabledSlapdObject
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Fixes: #208 

`exception.args[0]['ctrls']` is a list of the form of `(oid: str, criticality: int, berval: bytes)`.

I've choose `ctrls` instead of `controls` as the key of the dictionary because the other keys are also abbreviated like `desc`, `info`.