### PR TITLE
Python 3 has no basestring, use str instead

### DIFF
--- a/Lib/ldap/controls/sss.py
+++ b/Lib/ldap/controls/sss.py
@@ -12,6 +12,8 @@ __all__ = [
 ]
 
 
+import sys
+
 import ldap
 from ldap.ldapobject import LDAPObject
 from ldap.controls import (RequestControl, ResponseControl,
@@ -19,6 +21,10 @@ from ldap.controls import (RequestControl, ResponseControl,
 
 from pyasn1.type import univ, namedtype, tag, namedval, constraint
 from pyasn1.codec.ber import encoder, decoder
+
+PY2 = sys.version_info[0] <= 2
+if not PY2:
+  basestring = str
 
 
 #    SortKeyList ::= SEQUENCE OF SEQUENCE {

--- a/Tests/t_ldap_controls_sss.py
+++ b/Tests/t_ldap_controls_sss.py
@@ -1,0 +1,17 @@
+import os
+import unittest
+
+# Switch off processing .ldaprc or ldap.conf before importing _ldap
+os.environ['LDAPNOINIT'] = '1'
+
+from ldap.controls import sss
+
+
+class TestControlsPPolicy(unittest.TestCase):
+    def test_create_sss_request_control(self):
+        control = sss.SSSRequestControl(ordering_rules=['-uidNumber'])
+        self.assertEqual(control.ordering_rules, ['-uidNumber'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes: #255