### PR TITLE
Doc: Clarify and improve documentation of ldap.ldapobject.LDAPObject

### DIFF
--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -32,7 +32,7 @@ This module defines the following functions:
 .. py:function:: initialize(uri [, trace_level=0 [, trace_file=sys.stdout [, trace_stack_limit=None, [bytes_mode=None, [bytes_strictness=None]]]]]) -> LDAPObject object
 
    Initializes a new connection object for accessing the given LDAP server,
-   and return an LDAP object (see :ref:`ldap-objects`) used to perform operations
+   and return an :class:`~ldap.ldapobject.LDAPObject` used to perform operations
    on that server.
 
    The *uri* parameter may be a comma- or whitespace-separated list of URIs
@@ -63,7 +63,10 @@ This module defines the following functions:
    :py:const:`2` for logging the method calls with arguments and the complete results and
    :py:const:`9` for also logging the traceback of method calls.
 
-   Additional keyword arguments are passed to :class:`LDAPObject`.
+   This function is a thin wrapper around instantiating
+   :class:`~ldap.ldapobject.LDAPObject`.
+   Any additional keyword arguments are passed to ``LDAPObject``.
+   It is also fine to instantiate a ``LDAPObject`` (or a subclass) directly.
 
    .. seealso::
 
@@ -585,8 +588,13 @@ LDAPObject classes
    The connection is automatically unbound
    and closed when the LDAP object is deleted.
 
-   Internally :py:class:`LDAPObject` is set to
-   :py:class:`~ldap.ldapobject.SimpleLDAPObject` by default.
+   :py:class:`LDAPObject` is an alias of
+   :py:class:`~ldap.ldapobject.SimpleLDAPObject`, the default connection class.
+   If you wish to use a different class, instantiate it directly instead of
+   calling :func:`initialize()`.
+
+   (It is also possible, but not recommended, to change the default by setting
+   ``ldap.ldapobject.LDAPObject`` to a different class.)
 
 .. autoclass:: ldap.ldapobject.SimpleLDAPObject
 

--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -579,7 +579,7 @@ Warnings
 LDAPObject classes
 ==================
 
-.. py:class:: LDAPObject
+.. py:class:: ldap.ldapobject.LDAPObject
 
    Instances of :py:class:`LDAPObject` are returned by :py:func:`initialize()`.
    The connection is automatically unbound


### PR DESCRIPTION
### Use the full module in ldap.ldapobject.LDAPObject Doc

Previously, the class showed up as `ldap.LDAPObject`, which is wrong.

<s>Note that the documentation on Read the Docs is currently not building (see https://github.com/python-ldap/python-ldap/pull/260). The `SimpleLDAPObject` and `ReconnectLDAPObject` entries show up fine with current master, but not on the published docs.</s>

Fixes: https://github.com/python-ldap/python-ldap/issues/256

### Clarify and improve documentation of ldap.ldapobject.LDAPObject

Originally, `ldap.ldapobject.LDAPObject` was meant as a read/write alias of the "default" connection class.
However, setting module attributes is bad practice (action at distance): it affects all users of python-ldap, some of which might not be aware of each other.

Clarify that:
* `initialize()` is a thin wrapper around calling `LDAPObject()`,
* it is fine and recommnended to instantiate LDAPObject-like classes directly, and
* it is possible, but not recommended, to set `ldap.ldapobject.LDAPObject` to another class.

Fixes: https://github.com/python-ldap/python-ldap/issues/205