### PR TITLE
fix "not all arguments converted during string formatting" When Resul…

### DIFF
--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -526,7 +526,7 @@ class SimpleLDAPObject:
     except ldap.COMPARE_FALSE:
       return False
     raise ldap.PROTOCOL_ERROR(
-        'Compare operation returned wrong result: %r' % (ldap_res)
+        'Compare operation returned wrong result: %r' % repr(ldap_res)
     )
 
   def compare(self,dn,attr,value):


### PR DESCRIPTION
fix "not all arguments converted during string formatting" When ldap_res Result is a tuple
I tested whit FreeIPA