### PR TITLE
Update the changelog and release 3.2.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,27 @@
 ----------------------------------------------------------------
+Released 3.2.0 2019-03-13
+
+Lib/
+* Add support for X-ORIGIN in ldap.schema's ObjectClass
+* Make initialize() pass extra keyword arguments to LDAPObject
+* ldap.controls.sss: use str instead of basestring on Python 3
+* Provide ldap._trace_* atributes in non-debug mode
+
+Doc/
+* Fix ReST syntax for links to set_option and get_option
+
+Tests/
+* Use intersphinx to link to Python documentation
+* Correct type of some attribute values to bytes
+* Use system-specific ENOTCONN value
+
+Infrastructure:
+* Add testing and document support for Python 3.7
+* Add Python 3.8-dev to Tox and CI configuration
+* Add Doc/requirements.txt for building on Read the Docs
+
+
+----------------------------------------------------------------
 Released 3.1.0 2018-05-25
 
 This release brings two minor API changes:

--- a/Lib/ldap/pkginfo.py
+++ b/Lib/ldap/pkginfo.py
@@ -2,6 +2,6 @@
 """
 meta attributes for packaging which does not import any dependencies
 """
-__version__ = '3.1.0'
+__version__ = '3.2.0'
 __author__ = u'python-ldap project'
 __license__ = 'Python style'

--- a/Lib/ldapurl.py
+++ b/Lib/ldapurl.py
@@ -4,7 +4,7 @@ ldapurl - handling of LDAP URLs as described in RFC 4516
 See https://www.python-ldap.org/ for details.
 """
 
-__version__ = '3.1.0'
+__version__ = '3.2.0'
 
 __all__ = [
   # constants

--- a/Lib/ldif.py
+++ b/Lib/ldif.py
@@ -6,7 +6,7 @@ See https://www.python-ldap.org/ for details.
 
 from __future__ import unicode_literals
 
-__version__ = '3.1.0'
+__version__ = '3.2.0'
 
 __all__ = [
   # constants

--- a/Lib/slapdtest/__init__.py
+++ b/Lib/slapdtest/__init__.py
@@ -5,7 +5,7 @@ slapdtest - module for spawning test instances of OpenLDAP's slapd server
 See https://www.python-ldap.org/ for details.
 """
 
-__version__ = '3.1.0'
+__version__ = '3.2.0'
 
 from slapdtest._slapdtest import SlapdObject, SlapdTestCase, SysLogHandler
 from slapdtest._slapdtest import requires_ldapi, requires_sasl, requires_tls


### PR DESCRIPTION
With https://github.com/python-ldap/python-ldap/issues/226 fixed, it makes sense to do release.
We have a new feature, X-ORIGIN support, so the release should be 3.2.0.