### PR TITLE
Fix escape dn chars

### DIFF
--- a/Lib/ldap/dn.py
+++ b/Lib/ldap/dn.py
@@ -29,10 +29,10 @@ def escape_dn_chars(s):
     s = s.replace(';' ,'\\;')
     s = s.replace('=' ,'\\=')
     s = s.replace('\000' ,'\\\000')
-    if s[0]=='#' or s[0]==' ':
-      s = ''.join(('\\',s))
     if s[-1]==' ':
       s = ''.join((s[:-1],'\\ '))
+    if s[0]=='#' or s[0]==' ':
+      s = ''.join(('\\',s))
   return s
 
 

--- a/Tests/t_ldap_dn.py
+++ b/Tests/t_ldap_dn.py
@@ -50,6 +50,11 @@ class TestDN(unittest.TestCase):
         self.assertEqual(ldap.dn.escape_dn_chars('#foobar'), '\\#foobar')
         self.assertEqual(ldap.dn.escape_dn_chars('foo bar'), 'foo bar')
         self.assertEqual(ldap.dn.escape_dn_chars(' foobar'), '\\ foobar')
+        self.assertEqual(ldap.dn.escape_dn_chars(' '), '\\ ')
+        self.assertEqual(ldap.dn.escape_dn_chars('  '), '\\ \\ ')
+        self.assertEqual(ldap.dn.escape_dn_chars('foobar '), 'foobar\\ ')
+        self.assertEqual(ldap.dn.escape_dn_chars('f+o>o,b<a;r="\00"'), 'f\\+o\\>o\\,b\\<a\\;r\\=\\"\\\x00\\"')
+        self.assertEqual(ldap.dn.escape_dn_chars('foo\\,bar'), 'foo\\\\\\,bar')
 
     def test_str2dn(self):
         """


### PR DESCRIPTION
* Fixed escaping a single space ldap.dn.escpae_dn_chars(' ')
* Adjust the tests to include a test for every escaped character

See Issue #252