### PR TITLE
Fix TypeError in compare_s, test and document error behavior

### DIFF
--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -699,7 +699,9 @@ and wait for and return with the server's result, or with
    and the value *value*. The synchronous forms returns ``True`` or ``False``.
    The asynchronous forms returns the message ID of the initiated request, and
    the result of the asynchronous compare can be obtained using
-   :py:meth:`result()`.
+   :py:meth:`result()`. The operation can fail with an exception, e.g.
+   :py:exc:`ldap.NO_SUCH_OBJECT` when *dn* does not exist or
+   :py:exc:`ldap.UNDEFINED_TYPE` for an invalid attribute.
 
    Note that the asynchronous technique yields the answer
    by raising the exception objects :py:exc:`ldap.COMPARE_TRUE` or

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -526,7 +526,7 @@ class SimpleLDAPObject:
     except ldap.COMPARE_FALSE:
       return False
     raise ldap.PROTOCOL_ERROR(
-        'Compare operation returned wrong result: %r' % (ldap_res)
+        'Compare operation returned wrong result: %r' % (ldap_res,)
     )
 
   def compare(self,dn,attr,value):

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -661,6 +661,18 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
         result = l.compare_s('cn=Foo1,%s' % base, 'cn', b'Foo2')
         self.assertIs(result, False)
 
+    def test_compare_s_notfound(self):
+        base = self.server.suffix
+        l = self._ldap_conn
+        with self.assertRaises(ldap.NO_SUCH_OBJECT):
+            result = l.compare_s('cn=invalid,%s' % base, 'cn', b'Foo2')
+
+    def test_compare_s_invalidattr(self):
+        base = self.server.suffix
+        l = self._ldap_conn
+        with self.assertRaises(ldap.UNDEFINED_TYPE):
+            result = l.compare_s('cn=Foo1,%s' % base, 'invalidattr', b'invalid')
+
 
 class Test01_ReconnectLDAPObject(Test00_SimpleLDAPObject):
     """


### PR DESCRIPTION
## Fix string formatting in compare_ext_s

Pass ``(ldap_res,)`` tuple to string formatting instead of ``ldap_res``.
This changes fixes ``TypeError: not all arguments converted during string
formatting``.

Fixes: https://github.com/python-ldap/python-ldap/issues/270

## Test and document compare_s error cases
    
compare_s() may fail with an exception in case the DN is not found or the user searches for an unspecified attribute.
