### PR TITLE
Add ldap.filter.is_filter() which checks filter syntax

### DIFF
--- a/Lib/ldap/filter.py
+++ b/Lib/ldap/filter.py
@@ -7,6 +7,7 @@ Compatibility:
 - Tested with Python 2.0+
 """
 
+import _ldap
 from ldap import __version__
 
 from ldap.functions import strf_secs
@@ -89,3 +90,27 @@ def time_span_filter(
         until_timestr=strf_secs(until_timestamp),
     )
     # end of time_span_filter()
+
+
+def is_filter(ldap_filter):
+    """
+    Returns True if `ldap_filter' can be parsed as a valid LDAP filter, otherwise False is returned.
+    """
+    if hasattr(_ldap, 'is_filter'):
+        return _ldap.is_filter(ldap_filter)
+
+    # workaround for libldap <= 2.7
+    if '\x00' in ldap_filter:
+        raise ValueError('embedded null character')
+    import ldap
+    lo = ldap.initialize('')
+    try:
+        lo.search_ext_s('', ldap.SCOPE_BASE, ldap_filter)
+    except (ldap.FILTER_ERROR, TypeError, ValueError):
+        return False
+    except ldap.SERVER_DOWN:
+        # the filter syntax is valid, as the connection is not bound we expect SERVER_DOWN here
+        return True
+    finally:
+        lo.unbind()
+    raise RuntimeError('Could not check filter syntax.')  # can not happen

--- a/Lib/ldap/filter.py
+++ b/Lib/ldap/filter.py
@@ -7,6 +7,7 @@ Compatibility:
 - Tested with Python 2.0+
 """
 
+import _ldap
 from ldap import __version__
 
 from ldap.functions import strf_secs
@@ -89,3 +90,8 @@ def time_span_filter(
         until_timestr=strf_secs(until_timestamp),
     )
     # end of time_span_filter()
+
+
+def is_filter(ldap_filter: str):
+    """Returns True if `ldap_filter' can be parsed as a valid LDAP filter, otherwise False is returned."""
+    return _ldap.is_filter(ldap_filter)

--- a/Modules/functions.c
+++ b/Modules/functions.c
@@ -399,6 +399,31 @@ l_ldap_get_option(PyObject *self, PyObject *args)
     return LDAP_get_option(NULL, option);
 }
 
+
+#ifdef HAVE_LDAP_PUT_FILTER
+/* ldap_is_filter */
+static PyObject *l_ldap_is_filter(PyObject *self, PyObject *args)
+{
+    const char *filter;
+    if(!PyArg_ParseTuple(args, "s", &filter))
+        return NULL;
+
+    BerElement *ber = ber_alloc_t(LBER_USE_DER);
+    if(!ber) {
+        Py_RETURN_FALSE;
+    }
+
+    int rc = ldap_pvt_put_filter(ber, filter);
+    ber_free(ber, 1);
+
+    if (rc == 0) {
+        Py_RETURN_TRUE;
+    }
+    Py_RETURN_FALSE;
+}
+#endif
+
+
 /* methods */
 
 static PyMethodDef methods[] = {
@@ -410,6 +435,9 @@ static PyMethodDef methods[] = {
     {"dn2str", (PyCFunction)l_ldap_dn2str, METH_VARARGS},
     {"set_option", (PyCFunction)l_ldap_set_option, METH_VARARGS},
     {"get_option", (PyCFunction)l_ldap_get_option, METH_VARARGS},
+#ifdef HAVE_LDAP_PUT_FILTER
+    {"is_filter", (PyCFunction)l_ldap_is_filter, METH_VARARGS},
+#endif
     {NULL, NULL}
 };
 

--- a/Modules/functions.c
+++ b/Modules/functions.c
@@ -400,6 +400,32 @@ l_ldap_get_option(PyObject *self, PyObject *args)
     return LDAP_get_option(NULL, option);
 }
 
+
+/* ldap_is_filter */
+static PyObject *l_ldap_is_filter(PyObject *self, PyObject *args)
+{
+    const char *filter;
+    BerElement *ber;
+    int rc;
+
+    if(!PyArg_ParseTuple(args, "s:is_filter", &filter))
+        return NULL;
+
+    ber = ber_alloc_t(LBER_USE_DER);
+    if(ber == NULL) {
+        return PyErr_NoMemory();
+    }
+
+    rc = ldap_pvt_put_filter(ber, filter);
+    ber_free(ber, 1);
+
+    if (rc == 0) {
+        Py_RETURN_TRUE;
+    }
+    Py_RETURN_FALSE;
+}
+
+
 /* methods */
 
 static PyMethodDef methods[] = {
@@ -411,6 +437,7 @@ static PyMethodDef methods[] = {
     {"dn2str", (PyCFunction)l_ldap_dn2str, METH_VARARGS},
     {"set_option", (PyCFunction)l_ldap_set_option, METH_VARARGS},
     {"get_option", (PyCFunction)l_ldap_get_option, METH_VARARGS},
+    {"is_filter", (PyCFunction)l_ldap_is_filter, METH_VARARGS},
     {NULL, NULL}
 };
 

--- a/Modules/pythonldap.h
+++ b/Modules/pythonldap.h
@@ -42,6 +42,13 @@ LDAP_F(int) ldap_init_fd(ber_socket_t fd, int proto, LDAP_CONST char *url,
                          LDAP **ldp);
 #endif
 
+#if LDAP_VENDOR_VERSION >= 20700
+  /* openldap.h made ldap_pvt_put_filter() public in 2.7.x
+   * see https://bugs.openldap.org/show_bug.cgi?id=9393
+   */
+#define HAVE_LDAP_PUT_FILTER 1
+#endif
+
 #if defined(MS_WINDOWS)
 #include <winsock.h>
 #else /* unix */

--- a/Modules/pythonldap.h
+++ b/Modules/pythonldap.h
@@ -42,6 +42,17 @@ LDAP_F(int) ldap_init_fd(ber_socket_t fd, int proto, LDAP_CONST char *url,
                          LDAP **ldp);
 #endif
 
+#if LDAP_VENDOR_VERSION >= 20700
+  /* openldap.h made ldap_pvt_put_filter() public in 2.7.x
+   * see https://bugs.openldap.org/show_bug.cgi?id=9393
+   */
+#else
+  /* ldap_pvt_put_filter() has existed since OpenLDAP 2.1, but was only
+   * declared in the private ldap_pvt.h header before OpenLDAP 2.7.
+   */
+LDAP_F(int) ldap_pvt_put_filter LDAP_P((BerElement *ber, const char *str));
+#endif
+
 #if defined(MS_WINDOWS)
 #include <winsock.h>
 #else /* unix */

--- a/Tests/t_ldap_filter.py
+++ b/Tests/t_ldap_filter.py
@@ -10,13 +10,36 @@ import unittest
 # Switch off processing .ldaprc or ldap.conf before importing _ldap
 os.environ['LDAPNOINIT'] = '1'
 
-from ldap.filter import escape_filter_chars
+from ldap.filter import escape_filter_chars, is_filter, filter_format
 
 
-class TestDN(unittest.TestCase):
+class TestFilter(unittest.TestCase):
     """
     test ldap.functions
     """
+
+    def test_is_filter(self):
+        """
+        test function is_filter()
+        """
+        self.assertEqual(is_filter(''), True)
+        self.assertEqual(is_filter('foo='), True)
+        self.assertEqual(is_filter('foo=bar'), True)
+        self.assertEqual(is_filter('foo=*'), True)
+        self.assertEqual(is_filter(filter_format('foo=%s', ['*'])), True)
+        self.assertEqual(is_filter('(foo=bar)'), True)
+        self.assertEqual(is_filter('(&(foo=bar))'), True)
+        self.assertEqual(is_filter('(|(foo=bar))'), True)
+        self.assertEqual(is_filter(filter_format('foo=%s', ['\x00'])), True)
+        self.assertEqual(is_filter('foo>='), True)
+        self.assertEqual(is_filter('(foo>=)'), True)
+        self.assertEqual(is_filter('foo==bar'), True)
+        self.assertEqual(is_filter('foobar'), False)
+        self.assertEqual(is_filter('(foo='), False)
+        self.assertEqual(is_filter('foo=)'), False)
+        self.assertEqual(is_filter('=bar'), False)
+        with self.assertRaises(ValueError):
+            is_filter('foo=\x00')
 
     def test_escape_filter_chars_mode0(self):
         """

--- a/Tests/t_ldap_filter.py
+++ b/Tests/t_ldap_filter.py
@@ -10,13 +10,38 @@ import unittest
 # Switch off processing .ldaprc or ldap.conf before importing _ldap
 os.environ['LDAPNOINIT'] = '1'
 
-from ldap.filter import escape_filter_chars
+from ldap.filter import escape_filter_chars, is_filter, filter_format
 
 
-class TestDN(unittest.TestCase):
+class TestFilter(unittest.TestCase):
     """
     test ldap.functions
     """
+
+    def test_is_filter(self):
+        """
+        test function is_filter()
+        """
+        self.assertEqual(is_filter(''), True)
+        self.assertEqual(is_filter('foo='), True)
+        self.assertEqual(is_filter('foo=bar'), True)
+        self.assertEqual(is_filter('foo=*'), True)
+        self.assertEqual(is_filter(filter_format('foo=%s', ['*'])), True)
+        self.assertEqual(is_filter('(foo=bar)'), True)
+        self.assertEqual(is_filter('(&(foo=bar))'), True)
+        self.assertEqual(is_filter('(|(foo=bar))'), True)
+        self.assertEqual(is_filter(filter_format('foo=%s', ['\x00'])), True)
+        self.assertEqual(is_filter('foo>='), True)
+        self.assertEqual(is_filter('(foo>=)'), True)
+        self.assertEqual(is_filter('foo==bar'), True)
+        self.assertEqual(is_filter('foobar'), False)
+        self.assertEqual(is_filter('(foo='), False)
+        self.assertEqual(is_filter('foo=)'), False)
+        self.assertEqual(is_filter('=bar'), False)
+        with self.assertRaises(ValueError):
+            is_filter('foo=\x00')
+        with self.assertRaises(TypeError):
+            is_filter(object())
 
     def test_escape_filter_chars_mode0(self):
         """


### PR DESCRIPTION
Add a utility functions `ldap.filter.is_filter` which can be used to check if the ldap filter has valid syntax.
This uses an unbound ldap connection, so the values are ensured to be correct via the C library.
I added test cases for the function.