### PR TITLE
 Add ldap.dn.compare_dn() to compare equality of distinguished names 

### DIFF
--- a/Lib/ldap/dn.py
+++ b/Lib/ldap/dn.py
@@ -120,3 +120,10 @@ def is_dn(s,flags=0):
     return False
   else:
     return True
+
+
+def compare_dn(a, b):
+    """
+    Compares two distinguished names and return True if they are equal.
+    """
+    return [sorted((x.lower(), y, z) for x, y, z in rdn) for rdn in ldap.dn.str2dn(a)] == [sorted((x.lower(), y, z) for x, y, z in rdn) for rdn in ldap.dn.str2dn(b)]

--- a/Tests/t_ldap_dn.py
+++ b/Tests/t_ldap_dn.py
@@ -244,6 +244,19 @@ class TestDN(unittest.TestCase):
             ['cn=äöüÄÖÜß']
         )
 
+    def test_compare_dn(self):
+        self.assertEqual(ldap.dn.compare_dn('foo=1', 'foo=1'), True)
+        self.assertEqual(ldap.dn.compare_dn('foo=1', 'foo=2'), False)
+        self.assertEqual(ldap.dn.compare_dn('Foo=1', 'foo=1'), True)
+        self.assertEqual(ldap.dn.compare_dn('Foo=1', 'foo=2'), False)
+        self.assertEqual(ldap.dn.compare_dn('foo=1,bar=2', 'foo=1,bar=2'), True)
+        self.assertEqual(ldap.dn.compare_dn('bar=2,foo=1', 'foo=1,bar=2'), False)
+        self.assertEqual(ldap.dn.compare_dn('foo=1+bar=2', 'foo=1+bar=2'), True)
+        self.assertEqual(ldap.dn.compare_dn('bar=2+foo=1', 'foo=1+bar=2'), True)
+        self.assertEqual(ldap.dn.compare_dn('bar=2+Foo=1', 'foo=1+Bar=2'), True)
+        self.assertEqual(ldap.dn.compare_dn('foo=\\31', 'foo=1'), True)
+        #self.assertEqual(ldap.dn.compare_dn('uid=Foo', 'uid=foo'), True)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added a function which allows to compare two DN's for equality.

To be discussed: the third commit makes it possible to also compare the attribute values of a DN (e.g. "uid=Foo" == "uid=foo"). But it requires some initialization, as it depends on the actual used schema on the LDAP server.