### PR TITLE
Get rid of expected failures in tokenizer tests

### DIFF
--- a/Lib/ldap/schema/tokenizer.py
+++ b/Lib/ldap/schema/tokenizer.py
@@ -13,11 +13,15 @@ TOKENS_FINDALL = re.compile(
     r"|"              # or
     r"([^'$()\s]+)"   # string of length >= 1 without '$() or whitespace
     r"|"              # or
-    r"('.*?'(?!\w))"  # any string or empty string surrounded by single quotes
-                      # except if right quote is succeeded by alphanumeric char
+    r"('(?:[^'\\]|\\\\|\\.)*?'(?!\w))"
+                      # any string or empty string surrounded by unescaped
+                      # single quotes except if right quote is succeeded by
+                      # alphanumeric char
     r"|"              # or
     r"([^\s]+?)",     # residue, all non-whitespace strings
 ).findall
+
+UNESCAPE_PATTERN = re.compile(r"\\(.)")
 
 
 def split_tokens(s):
@@ -30,7 +34,7 @@ def split_tokens(s):
         if unquoted:
             parts.append(unquoted)
         elif quoted:
-            parts.append(quoted[1:-1])
+            parts.append(UNESCAPE_PATTERN.sub(r'\1', quoted[1:-1]))
         elif opar:
             parens += 1
             parts.append(opar)

--- a/Tests/t_ldap_schema_tokenizer.py
+++ b/Tests/t_ldap_schema_tokenizer.py
@@ -44,8 +44,8 @@ TESTCASES_UTF8 = (
 
 # broken schema of Oracle Internet Directory
 TESTCASES_BROKEN_OID = (
-    ("BLUBB DI 'BLU B B ER'MUST 'BLAH' ", ['BLUBB', 'DI', 'BLU B B ER', 'MUST', 'BLAH']),
-    ("BLUBBER DI 'BLU'BB ER' DA 'BLAH' ", ["BLUBBER", "DI", "BLU'BB ER", "DA", "BLAH"]),
+    "BLUBB DI 'BLU B B ER'MUST 'BLAH' ", #['BLUBB', 'DI', 'BLU B B ER', 'MUST', 'BLAH']
+    "BLUBBER DI 'BLU'BB ER' DA 'BLAH' ", #["BLUBBER", "DI", "BLU'BB ER", "DA", "BLAH"]
 )
 
 # for quoted single quotes inside string values
@@ -104,7 +104,6 @@ class TestSplitTokens(unittest.TestCase):
         """
         self._run_split_tokens_tests(TESTCASES_UTF8)
 
-    @unittest.expectedFailure
     def test_broken_oid(self):
         """
         run test cases specified in constant TESTCASES_BROKEN_OID

--- a/Tests/t_ldap_schema_tokenizer.py
+++ b/Tests/t_ldap_schema_tokenizer.py
@@ -110,7 +110,6 @@ class TestSplitTokens(unittest.TestCase):
         """
         self._run_failure_tests(TESTCASES_BROKEN_OID)
 
-    @unittest.expectedFailure
     def test_escaped_quotes(self):
         """
         run test cases specified in constant TESTCASES_ESCAPED_QUOTES


### PR DESCRIPTION
One of the failures actually stems from using the wrong method. Extending the tokenizer to deal with escapes gets rid of the other.