### PR TITLE
Fix reconnection handling

### DIFF
--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -736,6 +736,23 @@ class Test01_ReconnectLDAPObject(Test00_SimpleLDAPObject):
         l2 = pickle.loads(l1_state)
         self.assertEqual(l2.whoami_s(), 'dn:'+bind_dn)
 
+    def test105_reconnect_restore(self):
+        l1 = self.ldap_object_class(self.server.ldap_uri, retry_max=2, retry_delay=1)
+        bind_dn = 'cn=user1,'+self.server.suffix
+        l1.simple_bind_s(bind_dn, 'user1_pw')
+        self.assertEqual(l1.whoami_s(), 'dn:'+bind_dn)
+        self.server._proc.terminate()
+        self.server.wait()
+        try:
+            l1.whoami_s()
+        except ldap.SERVER_DOWN:
+            pass
+        else:
+            self.assertEqual(True, False)
+        finally:
+            self.server._start_slapd()
+        self.assertEqual(l1.whoami_s(), 'dn:'+bind_dn)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Considering the following code:
```python
import ldap
import subprocess

bind_dn = 'uid=Administrator,cn=users,l=school,l=dev'
bind_pw = 'univention'
ldap_addr = 'ldap://localhost:7389'


lo = ldap.ldapobject.ReconnectLDAPObject(ldap_addr, retry_max=2, retry_delay=1)
lo.bind_s(bind_dn, bind_pw)
subprocess.check_call(['systemctl', 'stop', 'slapd'])
try:
    _ = lo.search_s('l=school,l=dev', ldap.SCOPE_SUBTREE, '(uid=Administrator)')
except ldap.LDAPError as exc:
    print('Exception raised as expected')
    print(exc)
else:
    assert False, 'cannot happen'
finally:
    subprocess.check_call(['systemctl', 'start', 'slapd'])
print('\n######################')
print('Unexpected exception')
_ = lo.search_s('l=school,l=dev', ldap.SCOPE_SUBTREE, '(uid=Administrator)')
print(_)
```
which currently results in:
```
# python reproduce.py
Exception raised as expected
{'desc': "Can't contact LDAP server"}

######################
Unexpected exception
Traceback (most recent call last):
  File "reproduce.py", line 23, in <module>
    _ = lo.search_s('l=school,l=dev', ldap.SCOPE_SUBTREE, '(uid=Administrator)')
  File "/usr/lib/python2.7/dist-packages/ldap/ldapobject.py", line 597, in search_s
    return self.search_ext_s(base,scope,filterstr,attrlist,attrsonly,None,None,timeout=self.timeout)
  File "/usr/lib/python2.7/dist-packages/ldap/ldapobject.py", line 997, in search_ext_s
    return self._apply_method_s(SimpleLDAPObject.search_ext_s,*args,**kwargs)
  File "/usr/lib/python2.7/dist-packages/ldap/ldapobject.py", line 935, in _apply_method_s
    return func(self,*args,**kwargs)
  File "/usr/lib/python2.7/dist-packages/ldap/ldapobject.py", line 591, in search_ext_s
    return self.result(msgid,all=1,timeout=timeout)[1]
  File "/usr/lib/python2.7/dist-packages/ldap/ldapobject.py", line 503, in result
    resp_type, resp_data, resp_msgid = self.result2(msgid,all,timeout)
  File "/usr/lib/python2.7/dist-packages/ldap/ldapobject.py", line 507, in result2
    resp_type, resp_data, resp_msgid, resp_ctrls = self.result3(msgid,all,timeout)
  File "/usr/lib/python2.7/dist-packages/ldap/ldapobject.py", line 514, in result3
    resp_ctrl_classes=resp_ctrl_classes
  File "/usr/lib/python2.7/dist-packages/ldap/ldapobject.py", line 521, in result4
    ldap_result = self._ldap_call(self._l.result4,msgid,all,timeout,add_ctrls,add_intermediates,add_extop)
  File "/usr/lib/python2.7/dist-packages/ldap/ldapobject.py", line 106, in _ldap_call
    result = func(*args,**kwargs)
ldap.INSUFFICIENT_ACCESS: {'desc': 'Insufficient access'}
```

But it just should regulary do the reconnection.
I added a test case for the issue, let's see via Travis if the test is implemented well.