### PR TITLE
Add LICENSE file metadata to package distributions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+# Package metadata (for Setuptools 30.3 and later)
+[metadata]
+license_file = LICENCE
+
 # Example for setup.cfg
 # You have to edit this file to reflect your system configuation
 

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setup(
   #-- Package description
   name = name,
   license=pkginfo.__license__,
-  license_file=['LICENSE'],
   version=pkginfo.__version__,
   description = 'Python modules for implementing LDAP clients',
   long_description = """python-ldap:

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
   #-- Package description
   name = name,
   license=pkginfo.__license__,
-  license_files=['LICENSE'],
+  license_file=['LICENSE'],
   version=pkginfo.__version__,
   description = 'Python modules for implementing LDAP clients',
   long_description = """python-ldap:

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
   #-- Package description
   name = name,
   license=pkginfo.__license__,
+  license_files=['LICENSE'],
   version=pkginfo.__version__,
   description = 'Python modules for implementing LDAP clients',
   long_description = """python-ldap:


### PR DESCRIPTION
Currently [pip-licenses](https://github.com/raimon49/pip-licenses) can't include the LICENSE file for this project because the correct metadata is not setup.

This PR sets up the metadata correctly so the LICENSE file is properly included/linked to in source and wheel distributions.