### PR TITLE
avoid relying on undocumented OPT_X_TLS_NEWCTX behaviour

### DIFF
--- a/Demo/initialize.py
+++ b/Demo/initialize.py
@@ -40,7 +40,7 @@ l.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_DEMAND)
 # Set path name of file containing all trusted CA certificates
 l.set_option(ldap.OPT_X_TLS_CACERTFILE,CACERTFILE)
 # Force libldap to create a new SSL context (must be last TLS option!)
-l.set_option(ldap.OPT_X_TLS_NEWCTX,0)
+l.set_option(ldap.OPT_X_TLS_NEWCTX, 1)
 
 # Now try StartTLS extended operation
 l.start_tls_s()
@@ -70,7 +70,7 @@ l.set_option(ldap.OPT_X_TLS_REQUIRE_CERT,ldap.OPT_X_TLS_DEMAND)
 # Set path name of file containing all trusted CA certificates
 l.set_option(ldap.OPT_X_TLS_CACERTFILE,CACERTFILE)
 # Force libldap to create a new SSL context (must be last TLS option!)
-l.set_option(ldap.OPT_X_TLS_NEWCTX,0)
+l.set_option(ldap.OPT_X_TLS_NEWCTX, 1)
 
 # Try an explicit anon bind to provoke failure
 l.simple_bind_s('','')

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -825,7 +825,7 @@ class TestLdapCExtension(SlapdTestCase):
         l.set_option(_ldap.OPT_PROTOCOL_VERSION, _ldap.VERSION3)
         l.set_option(_ldap.OPT_X_TLS_CACERTFILE, self.server.cafile)
         # re-create TLS context
-        l.set_option(_ldap.OPT_X_TLS_NEWCTX, 0)
+        l.set_option(_ldap.OPT_X_TLS_NEWCTX, 1)
         l.start_tls_s()
 
     @requires_tls()
@@ -871,7 +871,7 @@ class TestLdapCExtension(SlapdTestCase):
         l.set_option(_ldap.OPT_X_TLS_CERTFILE, self.server.clientcert)
         l.set_option(_ldap.OPT_X_TLS_KEYFILE, self.server.clientkey)
         l.set_option(_ldap.OPT_X_TLS_REQUIRE_CERT, _ldap.OPT_X_TLS_HARD)
-        l.set_option(_ldap.OPT_X_TLS_NEWCTX, 0)
+        l.set_option(_ldap.OPT_X_TLS_NEWCTX, 1)
         l.start_tls_s()
 
     @requires_tls()

--- a/Tests/t_ldap_sasl.py
+++ b/Tests/t_ldap_sasl.py
@@ -82,7 +82,7 @@ class TestSasl(SlapdTestCase):
         ldap_conn.set_option(ldap.OPT_X_TLS_CERTFILE, self.server.clientcert)
         ldap_conn.set_option(ldap.OPT_X_TLS_KEYFILE, self.server.clientkey)
         ldap_conn.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_HARD)
-        ldap_conn.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
+        ldap_conn.set_option(ldap.OPT_X_TLS_NEWCTX, 1)
         ldap_conn.start_tls_s()
 
         auth = ldap.sasl.external()

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -614,7 +614,7 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
         for _ in range(10):
             l = self.ldap_object_class(self.server.ldap_uri)
             l.set_option(ldap.OPT_X_TLS_CACERTFILE, self.server.cafile)
-            l.set_option(ldap.OPT_X_TLS_NEWCTX, 0)
+            l.set_option(ldap.OPT_X_TLS_NEWCTX, 1)
             l.start_tls_s()
             l.simple_bind_s(self.server.root_dn, self.server.root_pw)
             self.assertEqual(l.whoami_s(), 'dn:' + self.server.root_dn)


### PR DESCRIPTION
The man page https://linux.die.net/man/3/ldap_set_option describes
the option as:

> Instructs the library to create a new TLS library context. invalue must be
const int *. A non-zero value pointed to by invalue tells the library to create
a context for a server.

so you would expect 0 to not create a new context. However as Howard, Chief Architect of OpenLDAP, Chu points out, setting 0 is undefined behavior and so libldap is free to behave in any way. It just so happens that non-zero and zero behave in the same way.

https://www.openldap.org/its/index.cgi/Incoming?id=8805
