### PR TITLE
create BYTES_MODE_MODERN and BYTES_MODE_LEGACY constants

### DIFF
--- a/Doc/bytes_mode.rst
+++ b/Doc/bytes_mode.rst
@@ -48,14 +48,15 @@ In Python 3, text values are represented as ``str``, the Unicode text type.
 In Python 2, the behavior of python-ldap 3.0 is influenced by a ``bytes_mode``
 argument to :func:`ldap.initialize`:
 
-``bytes_mode=True`` (backwards compatible):
+``bytes_mode=ldap.BYTES_MODE_LEGACY`` (backwards compatible):
     Text values are represented as bytes (``str``) encoded using UTF-8.
 
-``bytes_mode=False`` (future compatible):
+``bytes_mode=ldap.BYTES_MODE_MODERN`` (future compatible):
     Text values are represented as ``unicode``.
 
-If not given explicitly, python-ldap will default to ``bytes_mode=True``,
-but if an ``unicode`` value supplied to it, it will warn and use that value.
+If not given explicitly, python-ldap will default to
+``bytes_mode=ldap.BYTES_MODE_LGACY``, but if an ``unicode`` value is
+supplied to it, it will warn and use that value.
 
 Backwards-compatible behavior is not scheduled for removal until Python 2
 itself reaches end of life.
@@ -102,7 +103,7 @@ this are provided :ref:`in Python documentation <pyporting-howto>` and in the
 
 
 When porting from python-ldap 2.x, users are advised to update their code
-to set ``bytes_mode=False``, and fix any resulting failures.
+to set ``bytes_mode=ldap.BYTES_MODE_MODERN``, and fix any resulting failures.
 
 The typical usage is as follows.
 Note that only the result's *values* are of the ``bytes`` type:
@@ -110,7 +111,7 @@ Note that only the result's *values* are of the ``bytes`` type:
 .. code-block:: pycon
 
     >>> import ldap
-    >>> con = ldap.initialize('ldap://localhost:389', bytes_mode=False)
+    >>> con = ldap.initialize('ldap://localhost:389', bytes_mode=ldap.BYTES_MODE_MODERN)
     >>> con.simple_bind_s(u'login', u'secret_password')
     >>> results = con.search_s(u'ou=people,dc=example,dc=org', ldap.SCOPE_SUBTREE, u"(cn=Raphaël)")
     >>> results

--- a/Lib/ldap/__init__.py
+++ b/Lib/ldap/__init__.py
@@ -97,7 +97,10 @@ class LDAPLock:
 # Create module-wide lock for serializing all calls into underlying LDAP lib
 _ldap_module_lock = LDAPLock(desc='Module wide')
 
-from ldap.functions import initialize,get_option,set_option,escape_str,strf_secs,strp_secs
+from ldap.functions import (
+    initialize,get_option,set_option,escape_str,strf_secs,strp_secs,
+    BYTES_MODE_MODERN,BYTES_MODE_LEGACY,
+)
 
 from ldap.ldapobject import NO_UNIQUE_ENTRY, LDAPBytesWarning
 

--- a/Lib/ldap/functions.py
+++ b/Lib/ldap/functions.py
@@ -29,6 +29,8 @@ if __debug__:
 
 # See _raise_byteswarning in ldapobject.py
 _LDAP_WARN_SKIP_FRAME = True
+BYTES_MODE_MODERN = False
+BYTES_MODE_LEGACY = True
 
 
 def _ldap_function_call(lock,func,*args,**kwargs):

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -117,8 +117,9 @@ class SimpleLDAPObject:
                 _raise_byteswarning(
                   "Under Python 2, python-ldap uses bytes by default. "
                   "This will be removed in Python 3 (no bytes for "
-                  "DN/RDN/field names). "
-                  "Please call initialize(..., bytes_mode=False) explicitly.")
+                  "DN/RDN/field names). Please call "
+                  "initialize(..., bytes_mode=ldap.BYTES_MODE_MODERN) "
+                  "explicitly.")
                 bytes_strictness = 'warn'
         else:
             if bytes_strictness is None:


### PR DESCRIPTION
I have terrible trouble remembering if `bytes_mode=True` or `bytes_mode=False` is the correct newer modern flag