### PR TITLE
Doc: Remove duplicate entry for NO_OBJECT_CLASS_MODS

### DIFF
--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -458,10 +458,6 @@ The module defines the following exceptions:
 
 .. py:exception:: NO_MEMORY
 
-.. py:exception:: NO_OBJECT_CLASS_MODS
-
-   Object class modifications are not allowed.
-
 .. py:exception:: NO_RESULTS_RETURNED
 
 .. py:exception:: NO_SUCH_ATTRIBUTE


### PR DESCRIPTION
This fixes the build with newer versions of Sphinx.

(The entry is duplicated on line 444.)