### PR TITLE
Tox: replace setup.py test with unittest discover

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,9 +1,10 @@
 [run]
 branch = True
 source =
-    Lib/
-omit =
-    Lib/slapdtest.py
+   ldap
+   ldif
+   ldapurl
+   slapdtest
 
 [paths]
 source =

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,10 +68,6 @@ matrix:
       env: TOXENV=doc
   allow_failures:
      - env:
-        - TOXENV=py39
-        - CFLAGS_std="-std=c99"
-        - WITH_GCOV=1
-     - env:
         - TOXENV=pypy
 
 env:

--- a/tox.ini
+++ b/tox.ini
@@ -16,43 +16,49 @@ passenv = WITH_GCOV
 # - 'ignore:the imp module is deprecated' is required to ignore import of 'imp'
 #   in distutils. Python < 3.6 use PendingDeprecationWarning; Python >= 3.6 use
 #   DeprecationWarning.
+# - 'ignore:lib2to3 package' for Python 3.9
 commands = {envpython} -bb -Werror \
     "-Wignore:the imp module is deprecated:DeprecationWarning" \
     "-Wignore:the imp module is deprecated:PendingDeprecationWarning" \
     "-Wignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working:DeprecationWarning" \
-    -m coverage run --parallel setup.py \
-        clean --all \
-        test
+    "-Wignore:lib2to3 package is deprecated and may not be able to parse Python 3.10+:PendingDeprecationWarning" \
+    -m coverage run --parallel -m unittest discover -v -s Tests -p 't_*'
 
 [testenv:py27]
 # No warnings with Python 2.7
 passenv = {[testenv]passenv}
-commands = {envpython} \
-    -m coverage run --parallel setup.py test
+commands =
+    {envpython} -m coverage run --parallel \
+        -m unittest discover -v -s Tests -p 't_*'
 
 [testenv:py34]
 # No warnings with Python 3.4
 passenv = {[testenv]passenv}
-commands = {envpython} \
-    -m coverage run --parallel setup.py test
+commands = {[testenv:py27]commands}
 
 [testenv:py2-nosasltls]
 basepython = python2
-deps = {[testenv]deps}
+# don't install, install dependencies manually
+skip_install = true
+deps =
+    {[testenv]deps}
+    pyasn1
+    pyasn1_modules
 passenv = {[testenv]passenv}
 setenv =
     CI_DISABLED=LDAPI:SASL:TLS
-# rebuild without SASL and TLS, run without LDAPI
-commands = {envpython} \
-    -m coverage run --parallel setup.py \
-        clean --all \
-        build_ext -UHAVE_SASL,HAVE_TLS \
-        test
+# build and install without SASL and TLS, run without LDAPI
+commands =
+    {envpython} setup.py clean --all
+    {envpython} setup.py build_ext -UHAVE_SASL,HAVE_TLS
+    {envpython} setup.py install --single-version-externally-managed --root=/
+    {[testenv:py27]commands}
 
 [testenv:py3-nosasltls]
 basepython = python3
-deps = {[testenv]deps}
-passenv = {[testenv]passenv}
+skip_install = {[testenv:py2-nosasltls]skip_install}
+deps = {[testenv:py2-nosasltls]deps}
+passenv = {[testenv:py2-nosasltls]passenv}
 setenv = {[testenv:py2-nosasltls]setenv}
 commands = {[testenv:py2-nosasltls]commands}
 


### PR DESCRIPTION
setup.py test is deprecated and causes issues with testing our code.
There are cases where the wrong shared library is picked up.

The ``unittest discover`` approach avoids building the extension twice.

python-ldap should move to pytest eventually.

Fixes: https://github.com/python-ldap/python-ldap/issues/326
Signed-off-by: Christian Heimes <cheimes@redhat.com>