### PR TITLE
Deprecate cidict's strlist functions

### DIFF
--- a/Lib/ldap/cidict.py
+++ b/Lib/ldap/cidict.py
@@ -5,6 +5,7 @@ names of variable case.
 
 See https://www.python-ldap.org/ for details.
 """
+import warnings
 
 from ldap import __version__
 
@@ -62,6 +63,11 @@ def strlist_minus(a,b):
   Return list of all items in a which are not in b (a - b).
   a,b are supposed to be lists of case-insensitive strings.
   """
+  warnings.warn(
+    "strlist functions are deprecated and will be removed in 3.4",
+    category=DeprecationWarning,
+    stacklevel=2,
+  )
   temp = cidict()
   for elt in b:
     temp[elt] = elt
@@ -77,6 +83,11 @@ def strlist_intersection(a,b):
   """
   Return intersection of two lists of case-insensitive strings a,b.
   """
+  warnings.warn(
+    "strlist functions are deprecated and will be removed in 3.4",
+    category=DeprecationWarning,
+    stacklevel=2,
+  )
   temp = cidict()
   for elt in a:
     temp[elt] = elt
@@ -92,6 +103,11 @@ def strlist_union(a,b):
   """
   Return union of two lists of case-insensitive strings a,b.
   """
+  warnings.warn(
+    "strlist functions are deprecated and will be removed in 3.4",
+    category=DeprecationWarning,
+    stacklevel=2,
+  )
   temp = cidict()
   for elt in a:
     temp[elt] = elt

--- a/Tests/t_cidict.py
+++ b/Tests/t_cidict.py
@@ -7,6 +7,7 @@ See https://www.python-ldap.org/ for details.
 
 import os
 import unittest
+import warnings
 
 # Switch off processing .ldaprc or ldap.conf before importing _ldap
 os.environ['LDAPNOINIT'] = '1'
@@ -47,6 +48,19 @@ class TestCidict(unittest.TestCase):
         self.assertEqual("AbCDef" in cix, False)
         self.assertEqual(cix.has_key("abcdef"), False)
         self.assertEqual(cix.has_key("AbCDef"), False)
+
+    def test_strlist_deprecated(self):
+        strlist_funcs = [
+            ldap.cidict.strlist_intersection,
+            ldap.cidict.strlist_minus,
+            ldap.cidict.strlist_union
+        ]
+        for strlist_func in strlist_funcs:
+            with warnings.catch_warnings(record=True) as w:
+                warnings.resetwarnings()
+                warnings.simplefilter("always", DeprecationWarning)
+                strlist_func(["a"], ["b"])
+            self.assertEqual(len(w), 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The functions are undocumented, untested, unused, and can now be trivialy
implemented with set operations.

Signed-off-by: Christian Heimes <cheimes@redhat.com>