### PR TITLE
Allow LDAP connection from file descriptor 

### DIFF
--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -29,7 +29,7 @@ Functions
 
 This module defines the following functions:
 
-.. py:function:: initialize(uri [, trace_level=0 [, trace_file=sys.stdout [, trace_stack_limit=None, [bytes_mode=None, [bytes_strictness=None]]]]]) -> LDAPObject object
+.. py:function:: initialize(uri [, trace_level=0 [, trace_file=sys.stdout [, trace_stack_limit=None, [bytes_mode=None, [bytes_strictness=None, [fileno=None]]]]]]) -> LDAPObject object
 
    Initializes a new connection object for accessing the given LDAP server,
    and return an :class:`~ldap.ldapobject.LDAPObject` used to perform operations
@@ -39,6 +39,16 @@ This module defines the following functions:
    containing only the schema, the host, and the port fields. Note that
    when using multiple URIs you cannot determine to which URI your client
    gets connected.
+
+   If *fileno* parameter is given then the file descriptor will be used to
+   connect to an LDAP server. The *fileno* must either be a socket file
+   descriptor as :class:`int` or a file-like object with a *fileno()* method
+   that returns a socket file descriptor. The socket file descriptor must
+   already be connected. :class:`~ldap.ldapobject.LDAPObject` does not take
+   ownership of the file descriptor. It must be kept open during operations
+   and explicitly closed after the :class:`~ldap.ldapobject.LDAPObject` is
+   unbound. The internal connection type is determined from the URI, ``TCP``
+   for ``ldap://`` / ``ldaps://``, ``IPC`` (``AF_UNIX``) for ``ldapi://``.
 
    Note that internally the OpenLDAP function
    `ldap_initialize(3) <https://www.openldap.org/software/man.cgi?query=ldap_init&sektion=3>`_
@@ -71,6 +81,10 @@ This module defines the following functions:
    .. seealso::
 
       :rfc:`4516` - Lightweight Directory Access Protocol (LDAP): Uniform Resource Locator
+
+   .. versionadded:: 3.3
+
+      The *fileno* argument was added.
 
 
 .. py:function:: get_option(option) -> int|string

--- a/Lib/ldap/functions.py
+++ b/Lib/ldap/functions.py
@@ -67,7 +67,7 @@ def _ldap_function_call(lock,func,*args,**kwargs):
 
 def initialize(
     uri, trace_level=0, trace_file=sys.stdout, trace_stack_limit=None,
-    bytes_mode=None, **kwargs
+    bytes_mode=None, fileno=None, **kwargs
 ):
   """
   Return LDAPObject instance by opening LDAP connection to
@@ -84,12 +84,17 @@ def initialize(
         Default is to use stdout.
   bytes_mode
         Whether to enable :ref:`bytes_mode` for backwards compatibility under Py2.
+  fileno
+        If not None the socket file descriptor is used to connect to an
+        LDAP server.
 
   Additional keyword arguments (such as ``bytes_strictness``) are
   passed to ``LDAPObject``.
   """
   return LDAPObject(
-      uri, trace_level, trace_file, trace_stack_limit, bytes_mode, **kwargs)
+      uri, trace_level, trace_file, trace_stack_limit, bytes_mode,
+      fileno=fileno, **kwargs
+  )
 
 
 def get_option(option):

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -179,7 +179,7 @@ class SlapdObject(object):
     root_cn = 'Manager'
     root_pw = 'password'
     slapd_loglevel = 'stats stats2'
-    local_host = '127.0.0.1'
+    local_host = LOCALHOST
     testrunsubdirs = (
         'schema',
     )
@@ -214,7 +214,7 @@ class SlapdObject(object):
         self._schema_prefix = os.path.join(self.testrundir, 'schema')
         self._slapd_conf = os.path.join(self.testrundir, 'slapd.conf')
         self._db_directory = os.path.join(self.testrundir, "openldap-data")
-        self.ldap_uri = "ldap://%s:%d/" % (LOCALHOST, self._port)
+        self.ldap_uri = "ldap://%s:%d/" % (self.local_host, self._port)
         if HAVE_LDAPI:
             ldapi_path = os.path.join(self.testrundir, 'ldapi')
             self.ldapi_uri = "ldapi://%s" % quote_plus(ldapi_path)
@@ -242,6 +242,14 @@ class SlapdObject(object):
     @property
     def root_dn(self):
         return 'cn={self.root_cn},{self.suffix}'.format(self=self)
+
+    @property
+    def hostname(self):
+        return self.local_host
+
+    @property
+    def port(self):
+        return self._port
 
     def _find_commands(self):
         self.PATH_LDAPADD = self._find_command('ldapadd')

--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -1365,14 +1365,16 @@ l_ldap_start_tls_s(LDAPObject *self, PyObject *args)
 /* ldap_set_option */
 
 static PyObject *
-l_ldap_set_option(PyObject *self, PyObject *args)
+l_ldap_set_option(LDAPObject *self, PyObject *args)
 {
     PyObject *value;
     int option;
 
     if (!PyArg_ParseTuple(args, "iO:set_option", &option, &value))
         return NULL;
-    if (!LDAP_set_option((LDAPObject *)self, option, value))
+    if (not_valid(self))
+        return NULL;
+    if (!LDAP_set_option(self, option, value))
         return NULL;
     Py_INCREF(Py_None);
     return Py_None;
@@ -1381,13 +1383,15 @@ l_ldap_set_option(PyObject *self, PyObject *args)
 /* ldap_get_option */
 
 static PyObject *
-l_ldap_get_option(PyObject *self, PyObject *args)
+l_ldap_get_option(LDAPObject *self, PyObject *args)
 {
     int option;
 
     if (!PyArg_ParseTuple(args, "i:get_option", &option))
         return NULL;
-    return LDAP_get_option((LDAPObject *)self, option);
+    if (not_valid(self))
+        return NULL;
+    return LDAP_get_option(self, option);
 }
 
 /* ldap_passwd */

--- a/setup.py
+++ b/setup.py
@@ -145,6 +145,7 @@ setup(
           ('LDAPMODULE_VERSION', pkginfo.__version__),
           ('LDAPMODULE_AUTHOR', pkginfo.__author__),
           ('LDAPMODULE_LICENSE', pkginfo.__license__),
+          ('HAVE_LDAP_INIT_FD', None),
         ]
     ),
   ],


### PR DESCRIPTION
``ldap.initialize()`` now takes an optional fileno argument to create an
LDAP connection from a connected socket.

set_option() and get_option() now verify that LDAPObject is valid. This
fixes an assertion error and possible segfault after unbind_ext().