### PR TITLE
Don't overallocate memory in attrs_from_List()

### DIFF
--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -335,7 +335,7 @@ attrs_from_List(PyObject *attrlist, char ***attrsp)
              * internal values that must be treated like const char. Python
              * 3.7 actually returns a const char.
              */
-            attrs[i] = (char *)PyMem_NEW(char *, strlen + 1);
+            attrs[i] = (char *)PyMem_NEW(char, strlen + 1);
 
             if (attrs[i] == NULL)
                 goto nomem;


### PR DESCRIPTION
Allocate ``(strlen + 1) * sizeof(char)`` instead of
``(strlen + 1) * sizeof(char*)`` for a ``char[]`` in
``attrs_from_List()``.

Signed-off-by: Christian Heimes <cheimes@redhat.com>