### PR TITLE
Do not ignore warnings in tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,15 +13,7 @@ deps = coverage
 passenv = WITH_GCOV
 # - Enable BytesWarning
 # - Turn all warnings into exceptions.
-# - 'ignore:the imp module is deprecated' is required to ignore import of 'imp'
-#   in distutils. Python < 3.6 use PendingDeprecationWarning; Python >= 3.6 use
-#   DeprecationWarning.
-# - 'ignore:lib2to3 package' for Python 3.9
 commands = {envpython} -bb -Werror \
-    "-Wignore:the imp module is deprecated:DeprecationWarning" \
-    "-Wignore:the imp module is deprecated:PendingDeprecationWarning" \
-    "-Wignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working:DeprecationWarning" \
-    "-Wignore:lib2to3 package is deprecated and may not be able to parse Python 3.10+:PendingDeprecationWarning" \
     -m coverage run --parallel -m unittest discover -v -s Tests -p 't_*'
 
 [testenv:py27]


### PR DESCRIPTION
It looks like all the warnings were caused by setuptools.
Since we don't use setuptools in tests any more, we can remove the warnings.