### PR TITLE
LDAPUrl now treats urlscheme cases insensitive

### DIFF
--- a/Doc/reference/ldapurl.rst
+++ b/Doc/reference/ldapurl.rst
@@ -65,7 +65,7 @@ A :py:class:`LDAPUrl` object represents a complete LDAP URL.
 .. autoclass:: ldapurl.LDAPUrl
    :members:
 
-   .. versionchanged:: 3.3.0
+   .. versionchanged:: 3.4.0
 
       The urlscheme is now case insensitive and always converted to lower
       case. ``LDAP://localhost`` is equivalent to ``ldap://localhost``.

--- a/Doc/reference/ldapurl.rst
+++ b/Doc/reference/ldapurl.rst
@@ -65,6 +65,11 @@ A :py:class:`LDAPUrl` object represents a complete LDAP URL.
 .. autoclass:: ldapurl.LDAPUrl
    :members:
 
+   .. versionchanged:: 3.3.0
+
+      The urlscheme is now case insensitive and always converted to lower
+      case. ``LDAP://localhost`` is equivalent to ``ldap://localhost``.
+
 
 LDAP URL extensions
 ^^^^^^^^^^^^^^^^^^^

--- a/Lib/ldapurl.py
+++ b/Lib/ldapurl.py
@@ -48,14 +48,9 @@ TupleType=type(())
 
 
 def isLDAPUrl(s):
+  """Returns True if s is a LDAP URL, else False
   """
-  Returns 1 if s is a LDAP URL, 0 else
-  """
-  s_lower = s.lower()
-  return \
-    s_lower.startswith('ldap://') or \
-    s_lower.startswith('ldaps://') or \
-    s_lower.startswith('ldapi://')
+  return s.lower().startswith(('ldap://', 'ldaps://', 'ldapi://'))
 
 
 def ldapUrlEscape(s):
@@ -235,7 +230,7 @@ class LDAPUrl(object):
     extensions=None,
     who=None,cred=None
   ):
-    self.urlscheme=urlscheme
+    self.urlscheme=urlscheme.lower()
     self.hostport=hostport
     self.dn=dn
     self.attrs=attrs
@@ -270,9 +265,7 @@ class LDAPUrl(object):
     if not isLDAPUrl(ldap_url):
       raise ValueError('Value %s for ldap_url does not seem to be a LDAP URL.' % (repr(ldap_url)))
     scheme,rest = ldap_url.split('://',1)
-    self.urlscheme = scheme.strip()
-    if not self.urlscheme in ['ldap','ldaps','ldapi']:
-      raise ValueError('LDAP URL contains unsupported URL scheme %s.' % (self.urlscheme))
+    self.urlscheme = scheme.lower()
     slash_pos = rest.find('/')
     qemark_pos = rest.find('?')
     if (slash_pos==-1) and (qemark_pos==-1):

--- a/Tests/t_ldapurl.py
+++ b/Tests/t_ldapurl.py
@@ -34,18 +34,23 @@ class TestIsLDAPUrl(unittest.TestCase):
         'ldap://host.com:6666/o=University%20of%20Michigan,':1,
         'ldap://ldap.itd.umich.edu/c=GB?objectClass?one':1,
         'ldap://ldap.question.com/o=Question%3f,c=US?mail':1,
-        'ldap://ldap.netscape.com/o=Babsco,c=US??(int=%5c00%5c00%5c00%5c04)':1,
+        'ldap://ldap.netscape.com/o=Babsco,c=US???(int=%5c00%5c00%5c00%5c04)':1,
         'ldap:///??sub??bindname=cn=Manager%2co=Foo':1,
         'ldap:///??sub??!bindname=cn=Manager%2co=Foo':1,
         # More examples from various sources
         'ldap://ldap.nameflow.net:1389/c%3dDE':1,
         'ldap://root.openldap.org/dc=openldap,dc=org':1,
-        'ldap://root.openldap.org/dc=openldap,dc=org':1,
+        'ldaps://root.openldap.org/dc=openldap,dc=org':1,
         'ldap://x500.mh.se/o=Mitthogskolan,c=se????1.2.752.58.10.2=T.61':1,
         'ldp://root.openldap.org/dc=openldap,dc=org':0,
         'ldap://localhost:1389/ou%3DUnstructured%20testing%20tree%2Cdc%3Dstroeder%2Cdc%3Dcom??one':1,
         'ldaps://ldap.example.com/c%3dDE':1,
         'ldapi:///dc=stroeder,dc=de????x-saslmech=EXTERNAL':1,
+        'LDAP://localhost': True,
+        'LDAPS://localhost': True,
+        'LDAPI://%2Frun%2Fldap.sock': True,
+        ' ldap://space.example': False,
+        'ldap ://space.example': False,
     }
 
     def test_isLDAPUrl(self):
@@ -57,6 +62,11 @@ class TestIsLDAPUrl(unittest.TestCase):
                     ldap_url, result, expected,
                 )
             )
+            if expected:
+                LDAPUrl(ldapUrl=ldap_url)
+            else:
+                with self.assertRaises(Exception):
+                    LDAPUrl(ldapUrl=ldap_url)
 
 
 class TestParseLDAPUrl(unittest.TestCase):
@@ -141,6 +151,22 @@ class TestParseLDAPUrl(unittest.TestCase):
         'ldaps://localhost:12345/dc=stroeder,dc=com',
         LDAPUrl(
             urlscheme='ldaps',
+            hostport='localhost:12345',
+            dn='dc=stroeder,dc=com',
+        ),
+    ),
+    (
+        'LDAPS://localhost:12345/dc=stroeder,dc=com',
+        LDAPUrl(
+            urlscheme='ldaps',
+            hostport='localhost:12345',
+            dn='dc=stroeder,dc=com',
+        ),
+    ),
+    (
+        'ldaps://localhost:12345/dc=stroeder,dc=com',
+        LDAPUrl(
+            urlscheme='LDAPS',
             hostport='localhost:12345',
             dn='dc=stroeder,dc=com',
         ),

--- a/Tests/t_ldapurl.py
+++ b/Tests/t_ldapurl.py
@@ -65,7 +65,7 @@ class TestIsLDAPUrl(unittest.TestCase):
             if expected:
                 LDAPUrl(ldapUrl=ldap_url)
             else:
-                with self.assertRaises(Exception):
+                with self.assertRaises(ValueError):
                     LDAPUrl(ldapUrl=ldap_url)
 
 


### PR DESCRIPTION
Fixes: https://github.com/python-ldap/python-ldap/issues/280
Signed-off-by: Christian Heimes <cheimes@redhat.com>
Co-authored-by: David Mulder <dmulder@suse.com>