### PR TITLE
Syncrepl fails to parse SyncInfoMessage when the message is a syncIdSet

### DIFF
--- a/Lib/ldap/syncrepl.py
+++ b/Lib/ldap/syncrepl.py
@@ -314,34 +314,35 @@ class SyncInfoMessage:
         self.refreshPresent = None
         self.syncIdSet = None
 
-        for attr in ['newcookie', 'refreshDelete', 'refreshPresent', 'syncIdSet']:
-            comp = d[0].getComponentByName(attr)
+        # Due to the way pyasn1 works, refreshDelete and refreshPresent are both
+        # valid in the components as they are fully populated defaults. We must
+        # get the component directly from the message, not by iteration.
+        attr = d[0].getName()
+        comp = d[0].getComponent()
 
-            if comp is not None and comp.hasValue():
-
-                if attr == 'newcookie':
-                    self.newcookie = str(comp)
-                    return
-
-                val = {}
-
-                cookie = comp.getComponentByName('cookie')
-                if cookie.hasValue():
-                    val['cookie'] = str(cookie)
-
-                if attr.startswith('refresh'):
-                    val['refreshDone'] = bool(comp.getComponentByName('refreshDone'))
-                elif attr == 'syncIdSet':
-                    uuids = []
-                    ids = comp.getComponentByName('syncUUIDs')
-                    for i in range(len(ids)):
-                        uuid = UUID(bytes=bytes(ids.getComponentByPosition(i)))
-                        uuids.append(str(uuid))
-                    val['syncUUIDs'] = uuids
-                    val['refreshDeletes'] = bool(comp.getComponentByName('refreshDeletes'))
-
-                setattr(self, attr, val)
+        if comp is not None and comp.hasValue():
+            if attr == 'newcookie':
+                self.newcookie = str(comp)
                 return
+
+            val = {}
+
+            cookie = comp.getComponentByName('cookie')
+            if cookie.hasValue():
+                val['cookie'] = str(cookie)
+
+            if attr.startswith('refresh'):
+                val['refreshDone'] = bool(comp.getComponentByName('refreshDone'))
+            elif attr == 'syncIdSet':
+                uuids = []
+                ids = comp.getComponentByName('syncUUIDs')
+                for i in range(len(ids)):
+                    uuid = UUID(bytes=bytes(ids.getComponentByPosition(i)))
+                    uuids.append(str(uuid))
+                val['syncUUIDs'] = uuids
+                val['refreshDeletes'] = bool(comp.getComponentByName('refreshDeletes'))
+
+            setattr(self, attr, val)
 
 
 class SyncreplConsumer:

--- a/Tests/t_ldap_syncrepl.py
+++ b/Tests/t_ldap_syncrepl.py
@@ -478,7 +478,14 @@ class DecodeSyncreplProtoTests(unittest.TestCase):
         sim = SyncInfoMessage(msgraw)
         self.assertEqual(sim.refreshDelete, None)
         self.assertEqual(sim.refreshPresent, None)
-        self.assertNotEqual(sim.syncIdSet, None)
+        self.assertEqual(sim.newcookie, None)
+        self.assertEqual(sim.syncIdSet,
+            {
+                'cookie': 'ldapkdc.example.com:38901#cn=directory manager:dc=example,dc=com:(objectClass=*)#3',
+                'syncUUIDs': ['8dc44601-a936-11ea-8aaf-f248c5fa5780'],
+                'refreshDeletes': True
+            }
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously, the SyncInfoMessage parser used a for loop to test for the
presence of each named choice with with the structure. However, because
refreshDelete and refreshPresent both are able to be fully resolved
as defaults, and due to how pyasn1 accesses named types, it was not
checking the choice tag, and would return a fully populated refreshDelete
to the caller instead.

This fixes the parser to always return the inner component, and retrieves
the name based on the current choice of the tagged item.

Author: William Brown <william@blackhats.net.au>