### PR TITLE
Use openldap.h on OpenLDAP 2.4.48

### DIFF
--- a/Modules/LDAPObject.h
+++ b/Modules/LDAPObject.h
@@ -5,12 +5,6 @@
 
 #include "common.h"
 
-#include "lber.h"
-#include "ldap.h"
-#if LDAP_API_VERSION < 2040
-#error Current python-ldap requires OpenLDAP 2.4.x
-#endif
-
 #if PYTHON_API_VERSION < 1007
 typedef PyObject *_threadstate;
 #else

--- a/Modules/berval.h
+++ b/Modules/berval.h
@@ -4,7 +4,6 @@
 #define __h_berval
 
 #include "common.h"
-#include "lber.h"
 
 PyObject *LDAPberval_to_object(const struct berval *bv);
 PyObject *LDAPberval_to_unicode_object(const struct berval *bv);

--- a/Modules/common.h
+++ b/Modules/common.h
@@ -25,9 +25,6 @@
    * see https://bugs.openldap.org/show_bug.cgi?id=8671
    */
 #include <openldap.h>
-#ifndef HAVE_LDAP_INIT_FD
-#define HAVE_LDAP_INIT_FD
-#endif
 #else
   /* ldap_init_fd() has been around for a very long time
    * SSSD has been defining the function for a while, so it's probably OK.

--- a/Modules/common.h
+++ b/Modules/common.h
@@ -12,6 +12,33 @@
 #include "config.h"
 #endif
 
+#include <lber.h>
+#include <ldap.h>
+#include <ldap_features.h>
+
+#if LDAP_API_VERSION < 2040
+#error Current python-ldap requires OpenLDAP 2.4.x
+#endif
+
+#if LDAP_VENDOR_VERSION >= 20448
+  /* openldap.h with ldap_init_fd() was introduced in 2.4.48
+   * see https://bugs.openldap.org/show_bug.cgi?id=8671
+   */
+#include <openldap.h>
+#ifndef HAVE_LDAP_INIT_FD
+#define HAVE_LDAP_INIT_FD
+#endif
+#else
+  /* ldap_init_fd() has been around for a very long time
+   * SSSD has been defining the function for a while, so it's probably OK.
+   */
+#define LDAP_PROTO_TCP 1
+#define LDAP_PROTO_UDP 2
+#define LDAP_PROTO_IPC 3
+extern int ldap_init_fd(ber_socket_t fd, int proto, LDAP_CONST char *url,
+                        LDAP **ldp);
+#endif
+
 #if defined(MS_WINDOWS)
 #include <winsock.h>
 #else /* unix */

--- a/Modules/constants.c
+++ b/Modules/constants.c
@@ -4,8 +4,6 @@
 #include "common.h"
 #include "constants.h"
 #include "ldapcontrol.h"
-#include "lber.h"
-#include "ldap.h"
 
 /* the base exception class */
 

--- a/Modules/constants.h
+++ b/Modules/constants.h
@@ -4,8 +4,6 @@
 #define __h_constants_
 
 #include "common.h"
-#include "lber.h"
-#include "ldap.h"
 
 extern int LDAPinit_constants(PyObject *m);
 extern PyObject *LDAPconstant(int);

--- a/Modules/functions.c
+++ b/Modules/functions.c
@@ -30,8 +30,6 @@ l_ldap_initialize(PyObject *unused, PyObject *args)
     return (PyObject *)newLDAPObject(ld);
 }
 
-#ifdef HAVE_LDAP_INIT_FD
-
 /* initialize_fd(fileno, url) */
 
 static PyObject *
@@ -84,7 +82,6 @@ l_ldap_initialize_fd(PyObject *unused, PyObject *args)
 
     return (PyObject *)newLDAPObject(ld);
 }
-#endif /* HAVE_LDAP_INIT_FD */
 
 /* ldap_str2dn */
 
@@ -193,9 +190,7 @@ l_ldap_get_option(PyObject *self, PyObject *args)
 
 static PyMethodDef methods[] = {
     {"initialize", (PyCFunction)l_ldap_initialize, METH_VARARGS},
-#ifdef HAVE_LDAP_INIT_FD
     {"initialize_fd", (PyCFunction)l_ldap_initialize_fd, METH_VARARGS},
-#endif
     {"str2dn", (PyCFunction)l_ldap_str2dn, METH_VARARGS},
     {"set_option", (PyCFunction)l_ldap_set_option, METH_VARARGS},
     {"get_option", (PyCFunction)l_ldap_get_option, METH_VARARGS},

--- a/Modules/functions.c
+++ b/Modules/functions.c
@@ -32,20 +32,7 @@ l_ldap_initialize(PyObject *unused, PyObject *args)
 
 #ifdef HAVE_LDAP_INIT_FD
 
-/* initialize_fd(fileno, url)
- *
- * ldap_init_fd() is not a private API but it's not in a public header either
- * SSSD has been using the function for a while, so it's probably OK.
- */
-
-#ifndef LDAP_PROTO_TCP
-#define LDAP_PROTO_TCP 1
-#define LDAP_PROTO_UDP 2
-#define LDAP_PROTO_IPC 3
-#endif
-
-extern int
-  ldap_init_fd(ber_socket_t fd, int proto, LDAP_CONST char *url, LDAP **ldp);
+/* initialize_fd(fileno, url) */
 
 static PyObject *
 l_ldap_initialize_fd(PyObject *unused, PyObject *args)

--- a/Modules/ldapcontrol.c
+++ b/Modules/ldapcontrol.c
@@ -6,8 +6,6 @@
 #include "berval.h"
 #include "constants.h"
 
-#include "lber.h"
-
 /* Prints to stdout the contents of an array of LDAPControl objects */
 
 /* XXX: This is a debugging tool, and the printf generates some warnings

--- a/Modules/ldapcontrol.h
+++ b/Modules/ldapcontrol.h
@@ -4,7 +4,6 @@
 #define __h_ldapcontrol
 
 #include "common.h"
-#include "ldap.h"
 
 void LDAPinit_control(PyObject *d);
 void LDAPControl_List_DEL(LDAPControl **);

--- a/Modules/message.h
+++ b/Modules/message.h
@@ -4,8 +4,6 @@
 #define __h_message
 
 #include "common.h"
-#include "lber.h"
-#include "ldap.h"
 
 extern PyObject *LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls,
                                        int add_intermediates);

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,6 @@ setup(
           ('LDAPMODULE_VERSION', pkginfo.__version__),
           ('LDAPMODULE_AUTHOR', pkginfo.__author__),
           ('LDAPMODULE_LICENSE', pkginfo.__license__),
-          ('HAVE_LDAP_INIT_FD', None),
         ]
     ),
   ],


### PR DESCRIPTION
OpenLDAP 2.4.48 added openldap.h, which defines ldap_init_fd. Use the
header file with 2.4.48 and define the function for older versions.

The patch also cleans up #include. All OpenLDAP includes are now in
common.h and use global includes ``#include <ldap.h>`` instead of local
includes ``#include "ldap.h"``.

Fixes: https://github.com/python-ldap/python-ldap/issues/353
See: https://bugs.openldap.org/show_bug.cgi?id=8671
Signed-off-by: Christian Heimes <cheimes@redhat.com>