### PR TITLE
Add words to spellchecker

### DIFF
--- a/Doc/spelling_wordlist.txt
+++ b/Doc/spelling_wordlist.txt
@@ -56,6 +56,7 @@ filterstr
 filterStr
 formatOID
 func
+GPG
 Heimdal
 hostport
 hrefTarget
@@ -105,6 +106,7 @@ processResultsCount
 Proxied
 py
 rdn
+readthedocs
 reentrant
 refmodule
 refreshAndPersist


### PR DESCRIPTION
it looks like sphinxcontrib-spelling 5.1.2 does not like GPG and
readthedocs.

Signed-off-by: Christian Heimes <cheimes@redhat.com>