### PR TITLE
Prepare auto-formatting with black

### DIFF
--- a/Doc/contributing.rst
+++ b/Doc/contributing.rst
@@ -108,7 +108,7 @@ Notable targets are:
     Note that no backups are made – please commit any other changes before
     using this target.
 
-    Requires the ``indent`` program and the ``autopep8`` Python module.
+    Requires the ``indent`` program and the ``black`` Python module.
 
 .. _PEP 7: https://www.python.org/dev/peps/pep-0007/
 .. _PEP 8: https://www.python.org/dev/peps/pep-0008/

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ LCOV_REPORT_OPTIONS=--show-details -no-branch-coverage \
 	--title "python-ldap LCOV report"
 SCAN_REPORT=build/scan_report
 PYTHON_SUPP=/usr/share/doc/python3-devel/valgrind-python.supp
-AUTOPEP8_OPTS=--aggressive
+
 
 .NOTPARALLEL:
 
@@ -85,13 +85,15 @@ valgrind: build $(PYTHON_SUPP)
 	fi
 
 # Code autoformatter
-.PHONY: autoformat indent autopep8
-autoformat: indent autopep8
+.PHONY: autoformat indent black black-check
+autoformat: indent black
 
 indent:
 	indent Modules/*.c Modules/*.h
 	rm -f Modules/*.c~ Modules/*.h~
 
-autopep8:
-	$(PYTHON) -m autopep8 -r -i -j0 $(AUTOPEP8_OPTS) \
-	    Demo Lib Tests setup.py
+black:
+	$(PYTHON) -m black $(CURDIR)
+
+black-check:
+	$(PYTHON) -m black $(CURDIR) --check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.black]
+line-length = 88
+target-version = ['py36', 'py37', 'py38']
+
+[tool.isort]
+line_length=88
+known_first_party=['ldap', '_ldap', 'ldapurl', 'ldif', 'slapdtest']
+sections=['FUTURE', 'STDLIB', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']


### PR DESCRIPTION
Also removes autopep8 and prepares configuration for import sorter
isort.

Signed-off-by: Christian Heimes <cheimes@redhat.com>