### PR TITLE
tox positional arguments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ passenv = WITH_GCOV
 # - Enable BytesWarning
 # - Turn all warnings into exceptions.
 commands = {envpython} -bb -Werror \
-    -m unittest discover -v -s Tests -p 't_*'
+    -m unittest discover -v -s Tests -p 't_*' {posargs}
 
 [testenv:py3-nosasltls]
 basepython = python3
@@ -52,7 +52,7 @@ passenv = {[testenv]passenv}
 setenv =
     CI_DISABLED=INIT_FD
 commands =
-    {envpython} -m unittest -v \
+    {envpython} -m unittest -v {posargs} \
         Tests/t_cidict.py \
         Tests/t_ldap_dn.py \
         Tests/t_ldap_filter.py \
@@ -66,7 +66,7 @@ commands =
 [testenv:pypy3]
 basepython = pypy3
 deps = pytest
-commands = {envpython} -m pytest
+commands = {envpython} -m pytest {posargs}
 
 [testenv:doc]
 basepython = python3


### PR DESCRIPTION
Tox can pass positional arguments to test runners. This allows for instance to debug a single test with `tox -e py38 -- -f -k test_foobar`.