### PR TITLE
SlapdObject directory based configuration method, and slapadd implementation

### DIFF
--- a/Doc/spelling_wordlist.txt
+++ b/Doc/spelling_wordlist.txt
@@ -129,6 +129,7 @@ serverctrls
 sessionSourceIp
 sessionSourceName
 sessionTrackingIdentifier
+slapadd
 sizelimit
 slapd
 stderr

--- a/Doc/spelling_wordlist.txt
+++ b/Doc/spelling_wordlist.txt
@@ -132,6 +132,7 @@ sessionTrackingIdentifier
 slapadd
 sizelimit
 slapd
+startup
 stderr
 stdout
 str

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -174,6 +174,9 @@ class SlapdObject(object):
     manager, the slapd server is shut down and the temporary data store is
     removed.
 
+    :param openldap_schema_files: A list of schema names or schema paths to
+        load at startup. By default this only contains `core`.
+
     .. versionchanged:: 3.1
 
         Added context manager functionality

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -23,34 +23,33 @@ import ldap
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-# a template string for generating simple slapd.conf file
-SLAPD_CONF_TEMPLATE = r"""
-serverID %(serverid)s
-moduleload back_%(database)s
-%(include_directives)s
-loglevel %(loglevel)s
-allow bind_v2
+# a template string for generating simple slapd.d file
+SLAPD_CONF_TEMPLATE = r"""dn: cn=config
+objectClass: olcGlobal
+cn: config
+olcServerID: %(serverid)s
+olcLogLevel: %(loglevel)s
+olcAllows: bind_v2
+olcAuthzRegexp: {0}"gidnumber=%(root_gid)s\+uidnumber=%(root_uid)s,cn=peercred,cn=external,cn=auth" "%(rootdn)s"
+olcAuthzRegexp: {1}"C=DE, O=python-ldap, OU=slapd-test, CN=([A-Za-z]+)" "ldap://ou=people,dc=local???($1)"
+olcTLSCACertificateFile: %(cafile)s
+olcTLSCertificateFile: %(servercert)s
+olcTLSCertificateKeyFile: %(serverkey)s
+olcTLSVerifyClient: try
 
-authz-regexp
-  "gidnumber=%(root_gid)s\\+uidnumber=%(root_uid)s,cn=peercred,cn=external,cn=auth"
-  "%(rootdn)s"
+dn: cn=module,cn=config
+objectClass: olcModuleList
+cn: module
+olcModuleLoad: back_%(database)s
 
-database %(database)s
-directory "%(directory)s"
-suffix "%(suffix)s"
-rootdn "%(rootdn)s"
-rootpw "%(rootpw)s"
-
-TLSCACertificateFile "%(cafile)s"
-TLSCertificateFile "%(servercert)s"
-TLSCertificateKeyFile "%(serverkey)s"
-# ignore missing client cert but fail with invalid client cert
-TLSVerifyClient try
-
-authz-regexp
-    "C=DE, O=python-ldap, OU=slapd-test, CN=([A-Za-z]+)"
-    "ldap://ou=people,dc=local???($1)"
-
+dn: olcDatabase=%(database)s,cn=config
+objectClass: olcDatabaseConfig
+objectClass: olcMdbConfig
+olcDatabase: %(database)s
+olcSuffix: %(suffix)s
+olcRootDN: %(rootdn)s
+olcRootPW: %(rootpw)s
+olcDbDirectory: %(directory)s
 """
 
 LOCALHOST = '127.0.0.1'
@@ -188,9 +187,10 @@ class SlapdObject(object):
     local_host = LOCALHOST
     testrunsubdirs = (
         'schema',
+        'slapd.d',
     )
     openldap_schema_files = (
-        'core.schema',
+        'core.ldif',
     )
 
     TMPDIR = os.environ.get('TMP', os.getcwd())
@@ -218,7 +218,7 @@ class SlapdObject(object):
         self.server_id = self._port % 4096
         self.testrundir = os.path.join(self.TMPDIR, 'python-ldap-test-%d' % self._port)
         self._schema_prefix = os.path.join(self.testrundir, 'schema')
-        self._slapd_conf = os.path.join(self.testrundir, 'slapd.conf')
+        self._slapd_conf = os.path.join(self.testrundir, 'slapd.d')
         self._db_directory = os.path.join(self.testrundir, "openldap-data")
         self.ldap_uri = "ldap://%s:%d/" % (self.local_host, self._port)
         if HAVE_LDAPI:
@@ -262,6 +262,7 @@ class SlapdObject(object):
         self.PATH_LDAPDELETE = self._find_command('ldapdelete')
         self.PATH_LDAPMODIFY = self._find_command('ldapmodify')
         self.PATH_LDAPWHOAMI = self._find_command('ldapwhoami')
+        self.PATH_SLAPADD = self._find_command('slapadd')
 
         self.PATH_SLAPD = os.environ.get('SLAPD', None)
         if not self.PATH_SLAPD:
@@ -337,17 +338,9 @@ class SlapdObject(object):
         for generating specific static configuration files you have to
         override this method
         """
-        include_directives = '\n'.join(
-            'include "{schema_prefix}/{schema_file}"'.format(
-                schema_prefix=self._schema_prefix,
-                schema_file=schema_file,
-            )
-            for schema_file in self.openldap_schema_files
-        )
         config_dict = {
             'serverid': hex(self.server_id),
             'schema_prefix':self._schema_prefix,
-            'include_directives': include_directives,
             'loglevel': self.slapd_loglevel,
             'database': self.database,
             'directory': self._db_directory,
@@ -382,18 +375,25 @@ class SlapdObject(object):
             os.symlink(ln_source, ln_target)
 
     def _write_config(self):
-        """Writes the slapd.conf file out, and returns the path to it."""
-        self._log.debug('Writing config to %s', self._slapd_conf)
-        with open(self._slapd_conf, 'w') as config_file:
-            config_file.write(self.gen_config())
-        self._log.info('Wrote config to %s', self._slapd_conf)
+        """Loads the slapd.d configuration."""
+        self._log.debug("importing configuration: %s", self._slapd_conf)
+
+        self.slapadd(self.gen_config(), ["-n0"])
+        ldif_paths = [
+            os.path.join(self.SCHEMADIR, schema)
+            for schema in self.openldap_schema_files
+        ]
+        for ldif_path in ldif_paths:
+            self.slapadd(None, ["-n0", "-l", ldif_path])
+
+        self._log.debug("import ok: %s", self._slapd_conf)
 
     def _test_config(self):
         self._log.debug('testing config %s', self._slapd_conf)
         popen_list = [
             self.PATH_SLAPD,
             "-Ttest",
-            "-f", self._slapd_conf,
+            "-F", self._slapd_conf,
             "-u",
             "-v",
             "-d", "config"
@@ -417,8 +417,7 @@ class SlapdObject(object):
             urls.append(self.ldapi_uri)
         slapd_args = [
             self.PATH_SLAPD,
-            '-f', self._slapd_conf,
-            '-F', self.testrundir,
+            '-F', self._slapd_conf,
             '-h', ' '.join(urls),
         ]
         if self._log.isEnabledFor(logging.DEBUG):
@@ -523,10 +522,14 @@ class SlapdObject(object):
                    stdin_data=None):  # pragma: no cover
         if ldap_uri is None:
             ldap_uri = self.default_ldap_uri
-        args = [
-            ldapcommand,
-            '-H', ldap_uri,
-        ] + self._cli_auth_args() + (extra_args or [])
+
+        if ldapcommand.split("/")[-1].startswith("ldap"):
+            args = [ldapcommand, '-H', ldap_uri] + self._cli_auth_args()
+        else:
+            args = [ldapcommand, '-F', self._slapd_conf]
+
+        args += (extra_args or [])
+
         self._log.debug('Run command: %r', ' '.join(args))
         proc = subprocess.Popen(
             args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
@@ -576,6 +579,16 @@ class SlapdObject(object):
             extra_args.append('-r')
         extra_args.append(dn)
         self._cli_popen(self.PATH_LDAPDELETE, extra_args=extra_args)
+
+    def slapadd(self, ldif, extra_args=None):
+        """
+        Runs slapadd on this slapd instance, passing it the ldif content
+        """
+        self._cli_popen(
+            self.PATH_SLAPADD,
+            stdin_data=ldif.encode("utf-8") if ldif else None,
+            extra_args=extra_args,
+        )
 
     def __enter__(self):
         self.start()


### PR DESCRIPTION
Fixes #373 
Fixes #377

[This OpenLDAP documentation](https://www.openldap.org/doc/admin24/slapdconf2.html) tells:

> The older style slapd.conf(5) file is still supported, but its use is deprecated and support for it will be withdrawn in a future OpenLDAP release. Configuring slapd(8) via slapd.conf(5) is described in the next chapter.

This patch:
- makes slapd use the new directory based configuration method;
- implements the `SlapdObject.slapadd method`;
- tests the usage of `SlapdObject.slapadd method` by adding a custom schema;
- allow users to redefine `SlapdObject.openldap_schema_files` so they can load custom schemas at startup.