### PR TITLE
Python 3 syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ PKG-INFO
 
 # generated in the sample workflow
 /__venv__/
+
+# test dirs
+python-ldap-test-*

--- a/Demo/Lib/ldap/async/deltree.py
+++ b/Demo/Lib/ldap/async/deltree.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import ldap,ldap.async
 
 class DeleteLeafs(ldap.async.AsyncSearchHandler):

--- a/Demo/Lib/ldapurl/urlsearch.py
+++ b/Demo/Lib/ldapurl/urlsearch.py
@@ -3,7 +3,6 @@ Do a search with the LDAP URL specified at command-line.
 
 No output of LDAP data is produced except trace output.
 """
-from __future__ import print_function
 import sys,getpass,ldap,ldapurl
 
 try:

--- a/Demo/initialize.py
+++ b/Demo/initialize.py
@@ -7,7 +7,6 @@ ldap://localhost:1390 (LDAP with StartTLS)
 ldaps://localhost:1391 (LDAP over SSL)
 ldapi://%2ftmp%2fopenldap2 (domain socket /tmp/openldap2)
 """
-from __future__ import print_function
 
 import sys,os,ldap
 

--- a/Demo/ldapcontrols.py
+++ b/Demo/ldapcontrols.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import ldap,ldapurl,pprint
 
 from ldap.controls import LDAPControl,BooleanControl

--- a/Demo/ldapurl_search.py
+++ b/Demo/ldapurl_search.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys,pprint,ldap
 
 from ldap.ldapobject import LDAPObject

--- a/Demo/matchedvalues.py
+++ b/Demo/matchedvalues.py
@@ -27,7 +27,6 @@
 # Matched values control: (mail=*@example.org)
 # dn: uid=jsmith,ou=People,dc=example,dc=com
 # mail: jsmith@example.org
-from __future__ import print_function
 
 import ldap
 from ldap.controls import MatchedValuesControl
@@ -37,7 +36,7 @@ def print_result(search_result):
         print("dn: %s" % search_result[n][0])
         for attr in search_result[n][1].keys():
             for i in range(len(search_result[n][1][attr])):
-                print("%s: %s" % (attr, search_result[n][1][attr][i]))
+                print("{}: {}".format(attr, search_result[n][1][attr][i]))
         print
 
 

--- a/Demo/options.py
+++ b/Demo/options.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import ldap
 
 host="localhost:1390"

--- a/Demo/page_control.py
+++ b/Demo/page_control.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import print_function
-
 url = "ldap://localhost:1390"
 base = "dc=stroeder,dc=de"
 search_flt = r'(objectClass=*)'

--- a/Demo/paged_search_ext_s.py
+++ b/Demo/paged_search_ext_s.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 url = "ldap://localhost:1390/"
 base = "dc=stroeder,dc=de"
 search_flt = r'(objectClass=*)'

--- a/Demo/passwd_ext_op.py
+++ b/Demo/passwd_ext_op.py
@@ -1,7 +1,6 @@
 """
 Example showing the use of the password extended operation.
 """
-from __future__ import print_function
 
 import sys,ldap,ldapurl,getpass
 

--- a/Demo/pyasn1/dds.py
+++ b/Demo/pyasn1/dds.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Demo script for Dynamic Entries (see RFC 2589)
 
@@ -8,7 +7,6 @@ pyasn1
 pyasn1-modules
 python-ldap 2.4+
 """
-from __future__ import print_function
 
 from ldap.extop.dds import RefreshRequest,RefreshResponse
 

--- a/Demo/pyasn1/derefcontrol.py
+++ b/Demo/pyasn1/derefcontrol.py
@@ -3,7 +3,6 @@
 This sample script demonstrates the use of the dereference control
 (see https://tools.ietf.org/html/draft-masarati-ldap-deref)
 """
-from __future__ import print_function
 
 import pprint,ldap,ldap.modlist,ldap.resiter
 

--- a/Demo/pyasn1/noopsearch.py
+++ b/Demo/pyasn1/noopsearch.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Demo script for counting searching with OpenLDAP's no-op control
 
@@ -9,7 +8,6 @@ pyasn1
 pyasn1-modules
 python-ldap 2.4+
 """
-from __future__ import print_function
 
 import sys,ldap,ldapurl,getpass
 

--- a/Demo/pyasn1/ppolicy.py
+++ b/Demo/pyasn1/ppolicy.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Demo script for Password Policy Controls
 (see https://tools.ietf.org/html/draft-behera-ldap-password-policy)
@@ -9,7 +8,6 @@ pyasn1
 pyasn1-modules
 python-ldap 2.4+
 """
-from __future__ import print_function
 
 import sys,ldap,ldapurl,getpass
 

--- a/Demo/pyasn1/psearch.py
+++ b/Demo/pyasn1/psearch.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Demo script for Persistent Search Control
 (see https://tools.ietf.org/html/draft-ietf-ldapext-psearch)
@@ -10,7 +9,6 @@ pyasn1
 pyasn1-modules
 python-ldap 2.4+
 """
-from __future__ import print_function
 
 import sys,ldap,ldapurl,getpass
 

--- a/Demo/pyasn1/readentrycontrol.py
+++ b/Demo/pyasn1/readentrycontrol.py
@@ -4,7 +4,6 @@ This sample script demonstrates the use of the pre-read control (see RFC 4527).
 
 Originally contributed by Andreas Hasenack <ahasenack@terra.com.br>
 """
-from __future__ import print_function
 
 import pprint,ldap,ldap.modlist
 

--- a/Demo/pyasn1/sessiontrack.py
+++ b/Demo/pyasn1/sessiontrack.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
 demo_track_ldap_session.py
 
@@ -8,7 +7,6 @@ Client-side demo implementation of Session Tracking Control
 https://tools.ietf.org/html/draft-wahl-ldap-session-03
 """
 
-from __future__ import print_function
 
 __version__ = '0.1'
 

--- a/Demo/pyasn1/syncrepl.py
+++ b/Demo/pyasn1/syncrepl.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
 This script implements a syncrepl consumer which syncs data from an OpenLDAP
 server to a local (shelve) database.
@@ -8,7 +7,6 @@ Notes:
 
 The bound user needs read access to the attributes entryDN and entryCSN.
 """
-from __future__ import print_function
 
 # Import modules from Python standard lib
 import logging

--- a/Demo/rename.py
+++ b/Demo/rename.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import ldap
 from getpass import getpass
 

--- a/Demo/resiter.py
+++ b/Demo/resiter.py
@@ -4,7 +4,6 @@ written by Michael Stroeder <michael@stroeder.com>
 
 See https://www.python-ldap.org for details.
 """
-from __future__ import print_function
 
 import ldap,ldap.resiter
 

--- a/Demo/sasl_bind.py
+++ b/Demo/sasl_bind.py
@@ -1,6 +1,5 @@
 # For documentation, see comments in Module/LDAPObject.c and the
 # ldap.sasl module documentation.
-from __future__ import print_function
 
 import ldap,ldap.sasl
 

--- a/Demo/schema.py
+++ b/Demo/schema.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import sys,ldap,ldap.schema
 
 schema_attrs = ldap.schema.SCHEMA_ATTRS

--- a/Demo/schema_tree.py
+++ b/Demo/schema_tree.py
@@ -4,7 +4,6 @@ of a given server
 
 Usage: schema_oc_tree.py [--html] [LDAP URL]
 """
-from __future__ import print_function
 
 import sys,getopt,ldap,ldap.schema
 
@@ -28,10 +27,10 @@ def HTMLSchemaTree(schema,se_class,se_tree,se_oid,level):
   se_obj = schema.get_obj(se_class,se_oid)
   if se_obj!=None:
     print("""
-    <dt><strong>%s (%s)</strong></dt>
+    <dt><strong>{} ({})</strong></dt>
     <dd>
-      %s
-    """ % (', '.join(se_obj.names),se_obj.oid,se_obj.desc))
+      {}
+    """.format(', '.join(se_obj.names),se_obj.oid,se_obj.desc))
   if se_tree[se_oid]:
     print('<dl>')
     for sub_se_oid in se_tree[se_oid]:

--- a/Demo/simple.py
+++ b/Demo/simple.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import sys,getpass
 import ldap
 
@@ -86,7 +85,7 @@ l.add_s(dn,
 	("labeleduri",			["labeleduri"]),
 	("manager",			["cn=Jaga Indulska"]),
 	("reports",			["reports"]),
-	("jpegPhoto",			[open("/www/leonard/leonard.jpg","r").read()]),
+	("jpegPhoto",			[open("/www/leonard/leonard.jpg").read()]),
 	("uid",				["leonard"]),
 	("userPassword",		[""])
 

--- a/Demo/simplebrowse.py
+++ b/Demo/simplebrowse.py
@@ -3,7 +3,6 @@
 #
 # simple LDAP server browsing example
 #
-from __future__ import print_function
 
 import ldap
 from traceback import print_exc

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # python-ldap documentation build configuration file, created by
 # sphinx-quickstart on Sat Mar 29 15:08:17 2008.

--- a/Lib/ldap/__init__.py
+++ b/Lib/ldap/__init__.py
@@ -33,7 +33,7 @@ else:
 
 import _ldap
 assert _ldap.__version__==__version__, \
-       ImportError('ldap %s and _ldap %s version mismatch!' % (__version__,_ldap.__version__))
+       ImportError(f'ldap {__version__} and _ldap {_ldap.__version__} version mismatch!')
 from _ldap import *
 # call into libldap to initialize it right now
 LIBLDAP_API_INFO = _ldap.get_option(_ldap.OPT_API_INFO)
@@ -83,14 +83,14 @@ class LDAPLock:
     if __debug__:
       global _trace_level
       if _trace_level>=self._min_trace_level:
-        _trace_file.write('***%s.acquire() %s %s\n' % (self.__class__.__name__,repr(self),self._desc))
+        _trace_file.write('***{}.acquire() {} {}\n'.format(self.__class__.__name__,repr(self),self._desc))
     return self._lock.acquire()
 
   def release(self):
     if __debug__:
       global _trace_level
       if _trace_level>=self._min_trace_level:
-        _trace_file.write('***%s.release() %s %s\n' % (self.__class__.__name__,repr(self),self._desc))
+        _trace_file.write('***{}.release() {} {}\n'.format(self.__class__.__name__,repr(self),self._desc))
     return self._lock.release()
 
 

--- a/Lib/ldap/asyncsearch.py
+++ b/Lib/ldap/asyncsearch.py
@@ -30,7 +30,7 @@ class WrongResultType(Exception):
     Exception.__init__(self)
 
   def __str__(self):
-    return 'Received wrong result type %s (expected one of %s).' % (
+    return 'Received wrong result type {} (expected one of {}).'.format(
       self.receivedResultType,
       ', '.join(self.expectedResultTypes),
     )

--- a/Lib/ldap/constants.py
+++ b/Lib/ldap/constants.py
@@ -13,16 +13,15 @@ The information serves two purposes:
 # This module cannot import anything from ldap.
 # When building documentation, it is used to initialize ldap.__init__.
 
-from __future__ import print_function
 
-class Constant(object):
+class Constant:
     """Base class for a definition of an OpenLDAP constant
     """
 
     def __init__(self, name, optional=False, requirements=(), doc=None):
         self.name = name
         if optional:
-            self_requirement = 'defined(LDAP_{})'.format(self.name)
+            self_requirement = f'defined(LDAP_{self.name})'
             requirements = list(requirements) + [self_requirement]
         self.requirements = requirements
         self.doc = self.__doc__ = doc
@@ -50,7 +49,7 @@ class TLSInt(Int):
     def __init__(self, *args, **kwargs):
         requrements = list(kwargs.get('requirements', ()))
         kwargs['requirements'] = ['HAVE_TLS'] + requrements
-        super(TLSInt, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class Feature(Constant):
@@ -70,7 +69,7 @@ class Feature(Constant):
 
 
     def __init__(self, name, c_feature, **kwargs):
-        super(Feature, self).__init__(name, **kwargs)
+        super().__init__(name, **kwargs)
         self.c_feature = c_feature
 
 
@@ -392,7 +391,7 @@ def print_header():  # pragma: no cover
             if requirement not in current_requirements:
                 current_requirements.append(requirement)
                 print()
-                print('#if {}'.format(requirement))
+                print(f'#if {requirement}')
 
         print(definition.c_template.format(self=definition))
 

--- a/Lib/ldap/controls/__init__.py
+++ b/Lib/ldap/controls/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 controls.py - support classes for LDAP controls
 
@@ -13,7 +12,7 @@ from ldap.pkginfo import __version__
 
 import _ldap
 assert _ldap.__version__==__version__, \
-       ImportError('ldap %s and _ldap %s version mismatch!' % (__version__,_ldap.__version__))
+       ImportError(f'ldap {__version__} and _ldap {_ldap.__version__} version mismatch!')
 
 import ldap
 

--- a/Lib/ldap/controls/deref.py
+++ b/Lib/ldap/controls/deref.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ldap.controls.deref - classes for
 (see https://tools.ietf.org/html/draft-masarati-ldap-deref)

--- a/Lib/ldap/controls/libldap.py
+++ b/Lib/ldap/controls/libldap.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 controls.libldap - LDAP controls wrapper classes with en-/decoding done
 by OpenLDAP functions
@@ -10,7 +9,7 @@ from ldap.pkginfo import __version__
 
 import _ldap
 assert _ldap.__version__==__version__, \
-       ImportError('ldap %s and _ldap %s version mismatch!' % (__version__,_ldap.__version__))
+       ImportError(f'ldap {__version__} and _ldap {_ldap.__version__} version mismatch!')
 
 import ldap
 

--- a/Lib/ldap/controls/openldap.py
+++ b/Lib/ldap/controls/openldap.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ldap.controls.openldap - classes for OpenLDAP-specific controls
 

--- a/Lib/ldap/controls/pagedresults.py
+++ b/Lib/ldap/controls/pagedresults.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ldap.controls.paged - classes for Simple Paged control
 (see RFC 2696)

--- a/Lib/ldap/controls/ppolicy.py
+++ b/Lib/ldap/controls/ppolicy.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ldap.controls.ppolicy - classes for Password Policy controls
 (see https://tools.ietf.org/html/draft-behera-ldap-password-policy)

--- a/Lib/ldap/controls/psearch.py
+++ b/Lib/ldap/controls/psearch.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ldap.controls.psearch - classes for Persistent Search Control
 (see https://tools.ietf.org/html/draft-ietf-ldapext-psearch)

--- a/Lib/ldap/controls/pwdpolicy.py
+++ b/Lib/ldap/controls/pwdpolicy.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ldap.controls.pwdpolicy - classes for Password Policy controls
 (see https://tools.ietf.org/html/draft-vchu-ldap-pwd-policy)

--- a/Lib/ldap/controls/readentry.py
+++ b/Lib/ldap/controls/readentry.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ldap.controls.readentry - classes for the Read Entry controls
 (see RFC 4527)

--- a/Lib/ldap/controls/sessiontrack.py
+++ b/Lib/ldap/controls/sessiontrack.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ldap.controls.sessiontrack - class for session tracking control
 (see draft-wahl-ldap-session)

--- a/Lib/ldap/controls/simple.py
+++ b/Lib/ldap/controls/simple.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ldap.controls.simple - classes for some very simple LDAP controls
 

--- a/Lib/ldap/controls/sss.py
+++ b/Lib/ldap/controls/sss.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ldap.controls.sss - classes for Server Side Sorting
 (see RFC 2891)

--- a/Lib/ldap/controls/vlv.py
+++ b/Lib/ldap/controls/vlv.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ldap.controls.vlv - classes for Virtual List View
 (see draft-ietf-ldapext-ldapv3-vlv)

--- a/Lib/ldap/dn.py
+++ b/Lib/ldap/dn.py
@@ -7,7 +7,7 @@ from ldap.pkginfo import __version__
 
 import _ldap
 assert _ldap.__version__==__version__, \
-       ImportError('ldap %s and _ldap %s version mismatch!' % (__version__,_ldap.__version__))
+       ImportError(f'ldap {__version__} and _ldap {_ldap.__version__} version mismatch!')
 
 import ldap.functions
 

--- a/Lib/ldap/extop/__init__.py
+++ b/Lib/ldap/extop/__init__.py
@@ -28,7 +28,7 @@ class ExtendedRequest:
     self.requestValue = requestValue
 
   def __repr__(self):
-    return '%s(%s,%s)' % (self.__class__.__name__,self.requestName,self.requestValue)
+    return f'{self.__class__.__name__}({self.requestName},{self.requestValue})'
 
   def encodedRequestValue(self):
     """
@@ -53,7 +53,7 @@ class ExtendedResponse:
     self.responseValue = self.decodeResponseValue(encodedResponseValue)
 
   def __repr__(self):
-    return '%s(%s,%s)' % (self.__class__.__name__,self.responseName,self.responseValue)
+    return f'{self.__class__.__name__}({self.responseName},{self.responseValue})'
 
   def decodeResponseValue(self,value):
     """

--- a/Lib/ldap/extop/dds.py
+++ b/Lib/ldap/extop/dds.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ldap.extop.dds - Classes for Dynamic Entries extended operations
 (see RFC 2589)

--- a/Lib/ldap/extop/passwd.py
+++ b/Lib/ldap/extop/passwd.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ldap.extop.passwd - Classes for Password Modify extended operation
 (see RFC 3062)

--- a/Lib/ldap/filter.py
+++ b/Lib/ldap/filter.py
@@ -71,7 +71,7 @@ def time_span_filter(
         if from_timestamp < 0:
             from_timestamp = until_timestamp + from_timestamp
     if from_timestamp > until_timestamp:
-        raise ValueError('from_timestamp %r must not be greater than until_timestamp %r' % (
+        raise ValueError('from_timestamp {!r} must not be greater than until_timestamp {!r}'.format(
             from_timestamp, until_timestamp
         ))
     return (

--- a/Lib/ldap/functions.py
+++ b/Lib/ldap/functions.py
@@ -41,7 +41,7 @@ def _ldap_function_call(lock,func,*args,**kwargs):
     lock.acquire()
   if __debug__:
     if ldap._trace_level>=1:
-      ldap._trace_file.write('*** %s.%s %s\n' % (
+      ldap._trace_file.write('*** {}.{} {}\n'.format(
         '_ldap',func.__name__,
         pprint.pformat((args,kwargs))
       ))

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -114,7 +114,7 @@ class SimpleLDAPObject:
     self._ldap_object_lock.acquire()
     if __debug__:
       if self._trace_level>=1:
-        self._trace_file.write('*** %s %s - %s\n%s\n' % (
+        self._trace_file.write('*** {} {} - {}\n{}\n'.format(
           repr(self),
           self._uri,
           '.'.join((self.__class__.__name__,func.__name__)),
@@ -138,7 +138,7 @@ class SimpleLDAPObject:
       except IndexError:
         pass
       if __debug__ and self._trace_level>=2:
-        self._trace_file.write('=> LDAPError - %s: %s\n' % (e.__class__.__name__,str(e)))
+        self._trace_file.write('=> LDAPError - {}: {}\n'.format(e.__class__.__name__,str(e)))
       raise
     else:
       if __debug__ and self._trace_level>=2:
@@ -159,7 +159,7 @@ class SimpleLDAPObject:
     elif name in self.__dict__:
       return self.__dict__[name]
     else:
-      raise AttributeError('%s has no attribute %s' % (
+      raise AttributeError('{} has no attribute {}'.format(
         self.__class__.__name__,repr(name)
       ))
 
@@ -326,7 +326,7 @@ class SimpleLDAPObject:
     except ldap.COMPARE_FALSE:
       return False
     raise ldap.PROTOCOL_ERROR(
-        'Compare operation returned wrong result: %r' % (ldap_res,)
+        f'Compare operation returned wrong result: {ldap_res!r}'
     )
 
   def compare(self,dn,attr,value):
@@ -384,7 +384,7 @@ class SimpleLDAPObject:
     if extop_resp_class:
       respoid,respvalue = res
       if extop_resp_class.responseName!=respoid:
-        raise ldap.PROTOCOL_ERROR("Wrong OID in extended response! Expected %s, got %s" % (extop_resp_class.responseName,respoid))
+        raise ldap.PROTOCOL_ERROR(f"Wrong OID in extended response! Expected {extop_resp_class.responseName}, got {respoid}")
       return extop_resp_class(extop_resp_class.responseName,respvalue)
     else:
       return res
@@ -707,8 +707,8 @@ class SimpleLDAPObject:
 
     Returns: None or text/bytes depending on bytes_mode.
     """
-    empty_dn = u''
-    attrname = u'subschemaSubentry'
+    empty_dn = ''
+    attrname = 'subschemaSubentry'
     if dn is None:
       dn = empty_dn
     try:
@@ -760,7 +760,7 @@ class SimpleLDAPObject:
     """
     Returns the sub schema sub entry's data
     """
-    filterstr = u'(objectClass=subschema)'
+    filterstr = '(objectClass=subschema)'
     if attrs is None:
       attrs = SCHEMA_ATTRS
     try:
@@ -797,8 +797,8 @@ class SimpleLDAPObject:
     """
     convenience wrapper around read_s() for reading rootDSE
     """
-    base = u''
-    attrlist = attrlist or [u'*', u'+']
+    base = ''
+    attrlist = attrlist or ['*', '+']
     ldap_rootdse = self.read_s(
       base,
       filterstr=filterstr,
@@ -811,7 +811,7 @@ class SimpleLDAPObject:
     returns all attribute values of namingContexts in rootDSE
     if namingContexts is not present (not readable) then empty list is returned
     """
-    name = u'namingContexts'
+    name = 'namingContexts'
     return self.read_rootdse_s(
       attrlist=[name]
     ).get(name, [])
@@ -923,7 +923,7 @@ class ReconnectLDAPObject(SimpleLDAPObject):
       while reconnect_counter:
         counter_text = '%d. (of %d)' % (retry_max-reconnect_counter+1,retry_max)
         if __debug__ and self._trace_level>=1:
-          self._trace_file.write('*** Trying %s reconnect to %s...\n' % (
+          self._trace_file.write('*** Trying {} reconnect to {}...\n'.format(
             counter_text,uri
           ))
         try:
@@ -941,7 +941,7 @@ class ReconnectLDAPObject(SimpleLDAPObject):
             raise
         except (ldap.SERVER_DOWN,ldap.TIMEOUT):
           if __debug__ and self._trace_level>=1:
-            self._trace_file.write('*** %s reconnect to %s failed\n' % (
+            self._trace_file.write('*** {} reconnect to {} failed\n'.format(
               counter_text,uri
             ))
           reconnect_counter = reconnect_counter-1
@@ -952,7 +952,7 @@ class ReconnectLDAPObject(SimpleLDAPObject):
           time.sleep(retry_delay)
         else:
           if __debug__ and self._trace_level>=1:
-            self._trace_file.write('*** %s reconnect to %s successful => repeat last operation\n' % (
+            self._trace_file.write('*** {} reconnect to {} successful => repeat last operation\n'.format(
               counter_text,uri
             ))
           self._reconnects_done = self._reconnects_done + 1

--- a/Lib/ldap/logger.py
+++ b/Lib/ldap/logger.py
@@ -1,11 +1,10 @@
-# -*- coding: utf-8 -*-
 """
 Helper class for using logging as trace file object
 """
 
 import logging
 
-class logging_file_class(object):
+class logging_file_class:
 
     def __init__(self, logging_level):
         self._logging_level = logging_level

--- a/Lib/ldap/pkginfo.py
+++ b/Lib/ldap/pkginfo.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 """
 meta attributes for packaging which does not import any dependencies
 """
 __version__ = '3.3.0'
-__author__ = u'python-ldap project'
+__author__ = 'python-ldap project'
 __license__ = 'Python style'

--- a/Lib/ldap/schema/models.py
+++ b/Lib/ldap/schema/models.py
@@ -69,9 +69,9 @@ class SchemaElement:
     assert value is None or type(value)==str,TypeError("value has to be of str, was %r" % value)
     if value:
       if quoted:
-        return " %s '%s'" % (key,value.replace("'","\\'"))
+        return " {} '{}'".format(key,value.replace("'","\\'"))
       else:
-        return " %s %s" % (key,value)
+        return f" {key} {value}"
     else:
       return ""
 
@@ -84,9 +84,9 @@ class SchemaElement:
     else:
       quoted_values = values
     if len(values)==1:
-      return ' %s %s' % (key,quoted_values[0])
+      return ' {} {}'.format(key,quoted_values[0])
     else:
-      return ' %s ( %s )' % (key,sep.join(quoted_values))
+      return ' {} ( {} )'.format(key,sep.join(quoted_values))
 
   def __str__(self):
     result = [str(self.oid)]
@@ -133,7 +133,7 @@ class ObjectClass(SchemaElement):
     implementations to indicate the source of the associated schema
     element
   """
-  schema_attribute = u'objectClasses'
+  schema_attribute = 'objectClasses'
   token_defaults = {
     'NAME':(()),
     'DESC':(None,),
@@ -240,7 +240,7 @@ class AttributeType(SchemaElement):
     implementations to indicate the source of the associated schema
     element
   """
-  schema_attribute = u'attributeTypes'
+  schema_attribute = 'attributeTypes'
   token_defaults = {
     'NAME':(()),
     'DESC':(None,),
@@ -334,7 +334,7 @@ class LDAPSyntax(SchemaElement):
     Integer flag (0 or 1) indicating whether the attribute type is marked
     as not human-readable (X-NOT-HUMAN-READABLE)
   """
-  schema_attribute = u'ldapSyntaxes'
+  schema_attribute = 'ldapSyntaxes'
   token_defaults = {
     'DESC':(None,),
     'X-NOT-HUMAN-READABLE':(None,),
@@ -383,7 +383,7 @@ class MatchingRule(SchemaElement):
     OID of the LDAP syntax this matching rule is usable with
     (string, or None if missing)
   """
-  schema_attribute = u'matchingRules'
+  schema_attribute = 'matchingRules'
   token_defaults = {
     'NAME':(()),
     'DESC':(None,),
@@ -429,7 +429,7 @@ class MatchingRuleUse(SchemaElement):
     NAMEs or OIDs of attribute types for which this matching rule is used
     (tuple of strings)
   """
-  schema_attribute = u'matchingRuleUse'
+  schema_attribute = 'matchingRuleUse'
   token_defaults = {
     'NAME':(()),
     'DESC':(None,),
@@ -489,7 +489,7 @@ class DITContentRule(SchemaElement):
     NAMEs or OIDs of attributes which may not be present in an entry of the
     object class. (tuple of strings)
   """
-  schema_attribute = u'dITContentRules'
+  schema_attribute = 'dITContentRules'
   token_defaults = {
     'NAME':(()),
     'DESC':(None,),
@@ -547,7 +547,7 @@ class DITStructureRule(SchemaElement):
     NAMEs or OIDs of allowed structural object classes
     of superior entries in the DIT (tuple of strings)
   """
-  schema_attribute = u'dITStructureRules'
+  schema_attribute = 'dITStructureRules'
 
   token_defaults = {
     'NAME':(()),
@@ -610,7 +610,7 @@ class NameForm(SchemaElement):
     NAMEs or OIDs of additional attributes an RDN may contain
     (tuple of strings)
   """
-  schema_attribute = u'nameForms'
+  schema_attribute = 'nameForms'
   token_defaults = {
     'NAME':(()),
     'DESC':(None,),

--- a/Lib/ldap/schema/subentry.py
+++ b/Lib/ldap/schema/subentry.py
@@ -191,7 +191,7 @@ class SubSchema:
         # This helps with falsely assigned OIDs.
         continue
       assert se_obj.__class__==schema_element_class, \
-        "Schema element referenced by %s must be of class %s but was %s" % (
+        "Schema element referenced by {} must be of class {} but was {}".format(
           se_oid,schema_element_class.__name__,se_obj.__class__
         )
       for s in se_obj.sup or ('_',):
@@ -216,7 +216,7 @@ class SubSchema:
         result_oid = self.name2oid[se_class][nameoroid_stripped]
       except KeyError:
         if raise_keyerror:
-          raise KeyError('No registered %s-OID for nameoroid %s' % (se_class.__name__,repr(nameoroid_stripped)))
+          raise KeyError('No registered {}-OID for nameoroid {}'.format(se_class.__name__,repr(nameoroid_stripped)))
         else:
           result_oid = nameoroid_stripped
     return result_oid
@@ -249,7 +249,7 @@ class SubSchema:
       se_obj = self.sed[se_class][se_oid]
     except KeyError:
       if raise_keyerror:
-        raise KeyError('No ldap.schema.%s instance with nameoroid %s and se_oid %s' % (
+        raise KeyError('No ldap.schema.{} instance with nameoroid {} and se_oid {}'.format(
           se_class.__name__,repr(nameoroid),repr(se_oid))
         )
       else:
@@ -461,7 +461,7 @@ def urlfetch(uri,trace_level=0):
 
     l=ldap.initialize(ldap_url.initializeUrl(),trace_level)
     l.protocol_version = ldap.VERSION3
-    l.simple_bind_s(ldap_url.who or u'', ldap_url.cred or u'')
+    l.simple_bind_s(ldap_url.who or '', ldap_url.cred or '')
     subschemasubentry_dn = l.search_subschemasubentry_s(ldap_url.dn)
     if subschemasubentry_dn is None:
       s_temp = None

--- a/Lib/ldap/syncrepl.py
+++ b/Lib/ldap/syncrepl.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 ldap.syncrepl - for implementing syncrepl consumer (see RFC 4533)
 

--- a/Lib/ldapurl.py
+++ b/Lib/ldapurl.py
@@ -62,7 +62,7 @@ def ldapUrlEscape(s):
   """Returns URL encoding of string s"""
   return quote(s).replace(',','%2C').replace('/','%2F')
 
-class LDAPUrlExtension(object):
+class LDAPUrlExtension:
   """
   Class for parsing and unparsing LDAP URL extensions
   as described in RFC 4516.
@@ -103,9 +103,9 @@ class LDAPUrlExtension(object):
 
   def unparse(self):
     if self.exvalue is None:
-      return '%s%s' % ('!'*(self.critical>0),self.extype)
+      return '{}{}'.format('!'*(self.critical>0),self.extype)
     else:
-      return '%s%s=%s' % (
+      return '{}{}={}'.format(
         '!'*(self.critical>0),
         self.extype,quote(self.exvalue or '')
       )
@@ -114,7 +114,7 @@ class LDAPUrlExtension(object):
     return self.unparse()
 
   def __repr__(self):
-    return '<%s.%s instance at %s: %s>' % (
+    return '<{}.{} instance at {}: {}>'.format(
       self.__class__.__module__,
       self.__class__.__name__,
       hex(id(self)),
@@ -176,7 +176,7 @@ class LDAPUrlExtensions(MutableMapping):
         return ','.join(str(v) for v in self.values())
 
     def __repr__(self):
-        return '<%s.%s instance at %s: %s>' % (
+        return '<{}.{} instance at {}: {}>'.format(
             self.__class__.__module__,
             self.__class__.__name__,
             hex(id(self)),
@@ -198,7 +198,7 @@ class LDAPUrlExtensions(MutableMapping):
         return ','.join(v.unparse() for v in self.values())
 
 
-class LDAPUrl(object):
+class LDAPUrl:
   """
   Class for parsing and unparsing LDAP URLs
   as described in RFC 4516.
@@ -340,7 +340,7 @@ class LDAPUrl(object):
       hostport = ldapUrlEscape(self.hostport)
     else:
       hostport = self.hostport
-    return '%s://%s' % (self.urlscheme,hostport)
+    return f'{self.urlscheme}://{hostport}'
 
   def unparse(self):
     """
@@ -361,7 +361,7 @@ class LDAPUrl(object):
       hostport = ldapUrlEscape(self.hostport)
     else:
       hostport = self.hostport
-    ldap_url = '%s://%s/%s?%s?%s?%s' % (
+    ldap_url = '{}://{}/{}?{}?{}?{}'.format(
       self.urlscheme,
       hostport,dn,attrs_str,scope_str,filterstr
     )
@@ -395,7 +395,7 @@ class LDAPUrl(object):
             raise TypeError("hrefTarget must be str, not "
                             + type(hrefTarget).__name__)
         target = ' target="%s"' % hrefTarget
-    return '<a%s href="%s%s">%s</a>' % (
+    return '<a{} href="{}{}">{}</a>'.format(
         target, urlPrefix, self.unparse(), hrefText
     )
 
@@ -403,7 +403,7 @@ class LDAPUrl(object):
     return self.unparse()
 
   def __repr__(self):
-    return '<%s.%s instance at %s: %s>' % (
+    return '<{}.{} instance at {}: {}>'.format(
       self.__class__.__module__,
       self.__class__.__name__,
       hex(id(self)),
@@ -420,7 +420,7 @@ class LDAPUrl(object):
       else:
         return None
     else:
-      raise AttributeError('%s has no attribute %s' % (
+      raise AttributeError('{} has no attribute {}'.format(
         self.__class__.__name__,name
       ))
     return result # __getattr__()

--- a/Lib/slapdtest/__init__.py
+++ b/Lib/slapdtest/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 slapdtest - module for spawning test instances of OpenLDAP's slapd server
 

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 slapdtest - module for spawning test instances of OpenLDAP's slapd server
 
@@ -160,7 +159,7 @@ def combined_logger(
     return new_logger  # end of combined_logger()
 
 
-class SlapdObject(object):
+class SlapdObject:
     """
     Controller class for a slapd instance, OpenLDAP's server.
 

--- a/Tests/__init__.py
+++ b/Tests/__init__.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
 """
 Automatic tests for python-ldap
 
 See https://www.python-ldap.org/ for details.
 """
 
-from __future__ import absolute_import
 
 from . import t_bind
 from . import t_cext

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Automatic tests for python-ldap's C wrapper module _ldap
 
@@ -28,7 +27,7 @@ class TestLdapCExtension(SlapdTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestLdapCExtension, cls).setUpClass()
+        super().setUpClass()
         # add two initial objects after server was started and is still empty
         suffix_dc = cls.server.suffix.split(',')[0][3:]
         cls.server._log.debug(
@@ -52,14 +51,14 @@ class TestLdapCExtension(SlapdTestCase):
         )
 
     def setUp(self):
-        super(TestLdapCExtension, self).setUp()
+        super().setUp()
         self._writesuffix = None
 
     def tearDown(self):
         # cleanup test subtree
         if self._writesuffix is not None:
             self.server.ldapdelete(self._writesuffix, recursive=True)
-        super(TestLdapCExtension, self).tearDown()
+        super().tearDown()
 
     @property
     def writesuffix(self):
@@ -288,7 +287,7 @@ class TestLdapCExtension(SlapdTestCase):
             '',
             _ldap.SCOPE_BASE,
             '(objectClass=*)',
-            [str('objectClass'), str('namingContexts')],
+            ['objectClass', 'namingContexts'],
         )
         self.assertEqual(type(m), type(0))
         result, pmsg, msgid, ctrls = l.result4(m, _ldap.MSG_ALL, self.timeout)

--- a/Tests/t_cidict.py
+++ b/Tests/t_cidict.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Automatic tests for python-ldap's module ldap.cidict
 

--- a/Tests/t_edit.py
+++ b/Tests/t_edit.py
@@ -13,7 +13,7 @@ class EditionTests(SlapdTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(EditionTests, cls).setUpClass()
+        super().setUpClass()
         base = cls.server.suffix
         suffix_dc = base.split(',')[0][3:]
 

--- a/Tests/t_ldap_dn.py
+++ b/Tests/t_ldap_dn.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Automatic tests for python-ldap's module ldap.dn
 

--- a/Tests/t_ldap_filter.py
+++ b/Tests/t_ldap_filter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Automatic tests for python-ldap's module ldap.filter
 

--- a/Tests/t_ldap_functions.py
+++ b/Tests/t_ldap_functions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Automatic tests for python-ldap's module ldap.functions
 

--- a/Tests/t_ldap_modlist.py
+++ b/Tests/t_ldap_modlist.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Automatic tests for python-ldap's module ldap.modlist
 
@@ -44,7 +43,7 @@ class TestModlist(unittest.TestCase):
             result_modlist.sort()
             self.assertEqual(
                 test_modlist, result_modlist,
-                'addModlist(%s) returns\n%s\ninstead of\n%s.' % (
+                'addModlist({}) returns\n{}\ninstead of\n{}.'.format(
                     repr(entry),repr(result_modlist),repr(test_modlist)
                 )
             )
@@ -146,7 +145,7 @@ class TestModlist(unittest.TestCase):
 
             self.assertEqual(
                 test_modlist, result_modlist,
-                'modifyModlist(%s,%s) returns\n%s\ninstead of\n%s.' % (
+                'modifyModlist({},{}) returns\n{}\ninstead of\n{}.'.format(
                     repr(old_entry),
                     repr(new_entry),
                     repr(result_modlist),

--- a/Tests/t_ldap_options.py
+++ b/Tests/t_ldap_options.py
@@ -28,7 +28,7 @@ TEST_CTRL_EXPECTED = [
 ]
 
 
-class BaseTestOptions(object):
+class BaseTestOptions:
     """Common tests for getting/setting options
 
     Used in subclasses below
@@ -97,7 +97,7 @@ class BaseTestOptions(object):
             # data must be bytes or None
             self.set_option(
                 option,
-                [TEST_CTRL[0][0], TEST_CTRL[0][1], u'data']
+                [TEST_CTRL[0][0], TEST_CTRL[0][1], 'data']
             )
 
     def test_client_controls(self):

--- a/Tests/t_ldap_sasl.py
+++ b/Tests/t_ldap_sasl.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Automatic tests for python-ldap's module ldap.sasl
 
@@ -47,7 +46,7 @@ class TestSasl(SlapdTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(TestSasl, cls).setUpClass()
+        super().setUpClass()
         ldif = LDIF.format(
             suffix=cls.server.suffix,
             rootdn=cls.server.root_dn,
@@ -72,7 +71,7 @@ class TestSasl(SlapdTestCase):
         ldap_conn.sasl_interactive_bind_s("", auth)
         self.assertEqual(
             ldap_conn.whoami_s().lower(),
-            "dn:{}".format(self.server.root_dn.lower())
+            f"dn:{self.server.root_dn.lower()}"
         )
 
     @requires_tls()
@@ -89,7 +88,7 @@ class TestSasl(SlapdTestCase):
         ldap_conn.sasl_interactive_bind_s("", auth)
         self.assertEqual(
             ldap_conn.whoami_s().lower(),
-            "dn:{}".format(self.certsubject)
+            f"dn:{self.certsubject}"
         )
 
 if __name__ == '__main__':

--- a/Tests/t_ldap_schema_subentry.py
+++ b/Tests/t_ldap_schema_subentry.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Automatic tests for python-ldap's class ldap.schema.SubSchema
 

--- a/Tests/t_ldap_schema_tokenizer.py
+++ b/Tests/t_ldap_schema_tokenizer.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Automatic tests for python-ldap's module ldap.schema.tokenizer
 

--- a/Tests/t_ldap_syncrepl.py
+++ b/Tests/t_ldap_syncrepl.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Automatic tests for python-ldap's module ldap.syncrepl
 
@@ -249,7 +248,7 @@ class SyncreplClient(SimpleLDAPObject, SyncreplConsumer):
             pass
 
 
-class BaseSyncreplTests(object):
+class BaseSyncreplTests:
     """
     This is a test of all the basic Syncrepl operations.  It covers starting a
     search (both types of search), doing the refresh part of the search,
@@ -262,7 +261,7 @@ class BaseSyncreplTests(object):
 
     @classmethod
     def setUpClass(cls):
-        super(BaseSyncreplTests, cls).setUpClass()
+        super().setUpClass()
         # insert some Foo* objects via ldapadd
         cls.server.ldapadd(
             LDIF_TEMPLATE % {
@@ -275,13 +274,13 @@ class BaseSyncreplTests(object):
         )
 
     def setUp(self):
-        super(BaseSyncreplTests, self).setUp()
+        super().setUp()
         self.tester = None
         self.suffix = None
 
     def tearDown(self):
         self.tester.unbind_s()
-        super(BaseSyncreplTests, self).tearDown()
+        super().tearDown()
 
     def create_client(self):
         raise NotImplementedError
@@ -416,7 +415,7 @@ class BaseSyncreplTests(object):
 
 class TestSyncrepl(BaseSyncreplTests, SlapdTestCase):
     def setUp(self):
-        super(TestSyncrepl, self).setUp()
+        super().setUp()
         self.tester = SyncreplClient(
             self.server.ldap_uri,
             self.server.root_dn,

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Automatic tests for python-ldap's module ldap.ldapobject
 
@@ -72,7 +71,7 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(Test00_SimpleLDAPObject, cls).setUpClass()
+        super().setUpClass()
         # insert some Foo* objects via ldapadd
         cls.server.ldapadd(
             LDIF_TEMPLATE % {
@@ -270,11 +269,11 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
         self.assertEqual(
             sorted(subschema),
             [
-                u'attributeTypes',
-                u'ldapSyntaxes',
-                u'matchingRuleUse',
-                u'matchingRules',
-                u'objectClasses'
+                'attributeTypes',
+                'ldapSyntaxes',
+                'matchingRuleUse',
+                'matchingRules',
+                'objectClasses'
             ]
         )
 
@@ -291,7 +290,7 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
             info = ldap_err.args[0]['info']
             expected_info = os.strerror(errno.ENOTCONN)
             if info != expected_info:
-                self.fail("expected info=%r, got %r" % (expected_info, info))
+                self.fail(f"expected info={expected_info!r}, got {info!r}")
         else:
             self.fail("expected SERVER_DOWN, got %r" % r)
 
@@ -333,10 +332,10 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
     def test_simple_bind_noarg(self):
         l = self.ldap_object_class(self.server.ldap_uri)
         l.simple_bind_s()
-        self.assertEqual(l.whoami_s(), u'')
+        self.assertEqual(l.whoami_s(), '')
         l = self.ldap_object_class(self.server.ldap_uri)
         l.simple_bind_s(None, None)
-        self.assertEqual(l.whoami_s(), u'')
+        self.assertEqual(l.whoami_s(), '')
 
     def _check_byteswarning(self, warning, expected_message):
         self.assertIs(warning.category, ldap.LDAPBytesWarning)
@@ -374,16 +373,16 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
     def test_dse(self):
         dse = self._ldap_conn.read_rootdse_s()
         self.assertIsInstance(dse, dict)
-        self.assertEqual(dse[u'supportedLDAPVersion'], [b'3'])
+        self.assertEqual(dse['supportedLDAPVersion'], [b'3'])
         keys = set(dse)
         # SASL info may be missing in restricted build environments
-        keys.discard(u'supportedSASLMechanisms')
+        keys.discard('supportedSASLMechanisms')
         self.assertEqual(
             keys,
-            {u'configContext', u'entryDN', u'namingContexts', u'objectClass',
-             u'structuralObjectClass', u'subschemaSubentry',
-             u'supportedControl', u'supportedExtension', u'supportedFeatures',
-             u'supportedLDAPVersion'}
+            {'configContext', 'entryDN', 'namingContexts', 'objectClass',
+             'structuralObjectClass', 'subschemaSubentry',
+             'supportedControl', 'supportedExtension', 'supportedFeatures',
+             'supportedLDAPVersion'}
         )
         self.assertEqual(
             self._ldap_conn.get_naming_contexts(),
@@ -499,20 +498,20 @@ class Test01_ReconnectLDAPObject(Test00_SimpleLDAPObject):
         self.assertEqual(
             l1.__getstate__(),
             {
-                str('_last_bind'): (
+                '_last_bind': (
                     'simple_bind_s',
                     (bind_dn, 'user1_pw'),
                     {}
                 ),
-                str('_options'): [(17, 3)],
-                str('_reconnects_done'): 0,
-                str('_retry_delay'): 60.0,
-                str('_retry_max'): 1,
-                str('_start_tls'): 0,
-                str('_trace_level'): ldap._trace_level,
-                str('_trace_stack_limit'): 5,
-                str('_uri'): self.server.ldap_uri,
-                str('timeout'): -1,
+                '_options': [(17, 3)],
+                '_reconnects_done': 0,
+                '_retry_delay': 60.0,
+                '_retry_max': 1,
+                '_start_tls': 0,
+                '_trace_level': ldap._trace_level,
+                '_trace_stack_limit': 5,
+                '_uri': self.server.ldap_uri,
+                'timeout': -1,
             },
         )
 
@@ -552,14 +551,14 @@ class Test03_SimpleLDAPObjectWithFileno(Test00_SimpleLDAPObject):
         self._sock = socket.create_connection(
             (self.server.hostname, self.server.port)
         )
-        return super(Test03_SimpleLDAPObjectWithFileno, self)._open_ldap_conn(
+        return super()._open_ldap_conn(
             who=who, cred=cred, fileno=self._sock.fileno(), **kwargs
         )
 
     def tearDown(self):
         self._sock.close()
         del self._sock
-        super(Test03_SimpleLDAPObjectWithFileno, self).tearDown()
+        super().tearDown()
 
 
 if __name__ == '__main__':

--- a/Tests/t_ldapurl.py
+++ b/Tests/t_ldapurl.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Automatic tests for python-ldap's module ldapurl
 
@@ -160,7 +159,7 @@ class TestParseLDAPUrl(unittest.TestCase):
             ldap_url_obj = LDAPUrl(ldapUrl=ldap_url_str)
             self.assertEqual(
                 ldap_url_obj, test_ldap_url_obj,
-                'Attributes of LDAPUrl(%s) are:\n%s\ninstead of:\n%s' % (
+                'Attributes of LDAPUrl({}) are:\n{}\ninstead of:\n{}'.format(
                     repr(ldap_url_str),
                     repr(ldap_url_obj),
                     repr(test_ldap_url_obj),
@@ -170,7 +169,7 @@ class TestParseLDAPUrl(unittest.TestCase):
             unparsed_ldap_url_obj = LDAPUrl(ldapUrl=unparsed_ldap_url_str)
             self.assertEqual(
                 unparsed_ldap_url_obj, test_ldap_url_obj,
-                'Attributes of LDAPUrl(%s) are:\n%s\ninstead of:\n%s' % (
+                'Attributes of LDAPUrl({}) are:\n{}\ninstead of:\n{}'.format(
                     repr(unparsed_ldap_url_str),
                     repr(unparsed_ldap_url_obj),
                     repr(test_ldap_url_obj),

--- a/Tests/t_ldif.py
+++ b/Tests/t_ldif.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Automatic tests for python-ldap's module ldif
 


### PR DESCRIPTION
I applied the [pyupgrade](https://github.com/asottile/pyupgrade) tool to use a modern python syntax in the code.

```bash
find . -name "*.py" -exec pyupgrade --py36-plus "{}" +
```