### PR TITLE
Tidy up Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 group: travis_latest
 
-sudo: false
-
 cache: pip
 
 addons:
@@ -35,22 +33,16 @@ matrix:
         - TOXENV=py37
         - CFLAGS_std="-std=c99"
         - WITH_GCOV=1
-      dist: xenial
-      sudo: true
     - python: 3.8
       env:
         - TOXENV=py38
         - CFLAGS_std="-std=c99"
         - WITH_GCOV=1
-      dist: xenial
-      sudo: true
-    - python: 3.9-dev
+    - python: 3.9
       env:
         - TOXENV=py39
         - CFLAGS_std="-std=c99"
         - WITH_GCOV=1
-      dist: xenial
-      sudo: true
     - python: 3.6
       env:
         - TOXENV=py3-nosasltls


### PR DESCRIPTION
- Use the Python 3.9 release rather than '*-dev'
- Drop 'sudo' configuration as it is deprecated
- Drop 'dist: xenial' configuration, it is now the default

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration