### PR TITLE
Add missing cidict.copy() method

### DIFF
--- a/Lib/ldap/cidict.py
+++ b/Lib/ldap/cidict.py
@@ -53,6 +53,14 @@ class cidict(MutableMapping):
         self._keys.clear()
         self._data.clear()
 
+    def copy(self):
+        inst = self.__class__.__new__(self.__class__)
+        inst._data = self._data.copy()
+        inst._keys = self._keys.copy()
+        return inst
+
+    __copy__ = copy
+
     # Backwards compatibility
 
     def has_key(self, key):

--- a/Tests/t_cidict.py
+++ b/Tests/t_cidict.py
@@ -72,6 +72,19 @@ class TestCidict(unittest.TestCase):
         assert data == {'a': 1, 'b': 2}
         self.assertEqual(len(w), 1)
 
+    def test_copy(self):
+        cix1 = ldap.cidict.cidict(
+            {"a": 1, "B": 2}
+        )
+        cix2 = cix1.copy()
+        self.assertEqual(cix1, cix2)
+        cix1["c"] = 3
+        self.assertNotIn("c", cix2)
+        cix2["C"] = 4
+        self.assertNotEqual(cix1, cix2)
+        self.assertEqual(list(cix1.keys()), ["a", "B", "c"])
+        self.assertEqual(list(cix2.keys()), ["a", "B", "C"])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The copy() method vanished when cidict was re-implemented on top of
MutableMapping abstract base class.

See: commit 2a2cef38feb7f259ea6b5735a6ce3e46812e217d
Fixes: https://github.com/python-ldap/python-ldap/issues/387
Signed-off-by: Christian Heimes <cheimes@redhat.com>