### PR TITLE
Make parameters configurable for SlapdObject

### DIFF
--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -224,9 +224,17 @@ class SlapdObject(object):
     # create loggers once, multiple calls mess up refleak tests
     _log = None
 
-    def __init__(self, host=None, port=None, log_level=logging.WARN):
+    def __init__(self,
+                 host=None,
+                 port=None,
+                 log_level=logging.WARN,
+                 openldap_schema_files=None,
+                 ):
         if SlapdObject._log is None:
             SlapdObject._log = combined_logger('python-ldap-test', log_level=log_level)
+
+        if openldap_schema_files is not None:
+            self.openldap_schema_files = openldap_schema_files
 
         self._proc = None
         self._port = port or self._avail_tcp_port()

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -125,7 +125,7 @@ def _add_sbin(path):
 
 def combined_logger(
         log_name,
-        log_level=logging.WARN,
+        log_level,
         sys_log_format='%(levelname)s %(message)s',
         console_log_format='%(asctime)s %(levelname)s %(message)s',
     ):
@@ -183,6 +183,10 @@ class SlapdObject(object):
     :param port: The port on which the slapd server will listen to.
         If `None` a random available port will be chosen.
 
+    :param log_level: The verbosity of SlapdObject..
+        The default value is `logging.WARNING`.
+
+
     .. versionchanged:: 3.1
 
         Added context manager functionality
@@ -218,9 +222,12 @@ class SlapdObject(object):
     _start_sleep = 1.5
 
     # create loggers once, multiple calls mess up refleak tests
-    _log = combined_logger('python-ldap-test')
+    _log = None
 
-    def __init__(self, host=None, port=None):
+    def __init__(self, host=None, port=None, log_level=logging.WARN):
+        if SlapdObject._log is None:
+            SlapdObject._log = combined_logger('python-ldap-test', log_level=log_level)
+
         self._proc = None
         self._port = port or self._avail_tcp_port()
         self.server_id = self._port % 4096

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -196,7 +196,7 @@ class SlapdObject(object):
     :param datadir_prefix: The prefix of the temporary directory where the slapd
         configuration and data will be stored. The default value is `python-ldap-test`.
 
-    :param debug: Wether to launch slapd with debug verbosity on. When `True` debug is enabled,
+    :param debug: Whether to launch slapd with debug verbosity on. When `True` debug is enabled,
         when `False` debug is disabled, when `None`, debug is only enable when *log_level* is
         `logging.DEBUG`. Default value is `None`.
 

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -196,6 +196,10 @@ class SlapdObject(object):
     :param datadir_prefix: The prefix of the temporary directory where the slapd
         configuration and data will be stored. The default value is `python-ldap-test`.
 
+    :param debug: Wether to launch slapd with debug verbosity on. When `True` debug is enabled,
+        when `False` debug is disabled, when `None`, debug is only enable when *log_level* is
+        `logging.DEBUG`. Default value is `None`.
+
     .. versionchanged:: 3.1
 
         Added context manager functionality
@@ -243,6 +247,7 @@ class SlapdObject(object):
                  root_cn=None,
                  root_pw=None,
                  datadir_prefix=None,
+                 debug=None,
                  ):
         if self._log is None:
             self._log = combined_logger('python-ldap-test', log_level=log_level)
@@ -269,6 +274,7 @@ class SlapdObject(object):
         self._slapd_conf = os.path.join(self.testrundir, 'slapd.d')
         self._db_directory = os.path.join(self.testrundir, "openldap-data")
         self.ldap_uri = "ldap://%s:%d/" % (host or self.local_host, self._port)
+        self.debug = debug
         if HAVE_LDAPI:
             ldapi_path = os.path.join(self.testrundir, 'ldapi')
             self.ldapi_uri = "ldapi://%s" % quote_plus(ldapi_path)
@@ -458,7 +464,7 @@ class SlapdObject(object):
             '-F', self._slapd_conf,
             '-h', ' '.join(urls),
         ]
-        if self._log.isEnabledFor(logging.DEBUG):
+        if self.debug is True or (self.debug is None and self._log.isEnabledFor(logging.DEBUG)):
             slapd_args.extend(['-d', '-1'])
         else:
             slapd_args.extend(['-d', '0'])

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -177,6 +177,12 @@ class SlapdObject(object):
     :param openldap_schema_files: A list of schema names or schema paths to
         load at startup. By default this only contains `core`.
 
+    :param host: The host on which the slapd server will listen to.
+        The default value is `127.0.0.1`.
+
+    :param port: The port on which the slapd server will listen to.
+        If `None` a random available port will be chosen.
+
     .. versionchanged:: 3.1
 
         Added context manager functionality
@@ -214,14 +220,14 @@ class SlapdObject(object):
     # create loggers once, multiple calls mess up refleak tests
     _log = combined_logger('python-ldap-test')
 
-    def __init__(self):
+    def __init__(self, host=None, port=None):
         self._proc = None
-        self._port = self._avail_tcp_port()
+        self._port = port or self._avail_tcp_port()
         self.server_id = self._port % 4096
         self.testrundir = os.path.join(self.TMPDIR, 'python-ldap-test-%d' % self._port)
         self._slapd_conf = os.path.join(self.testrundir, 'slapd.d')
         self._db_directory = os.path.join(self.testrundir, "openldap-data")
-        self.ldap_uri = "ldap://%s:%d/" % (self.local_host, self._port)
+        self.ldap_uri = "ldap://%s:%d/" % (host or self.local_host, self._port)
         if HAVE_LDAPI:
             ldapi_path = os.path.join(self.testrundir, 'ldapi')
             self.ldapi_uri = "ldapi://%s" % quote_plus(ldapi_path)

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -229,12 +229,28 @@ class SlapdObject(object):
                  port=None,
                  log_level=logging.WARN,
                  openldap_schema_files=None,
+                 database=None,
+                 suffix=None,
+                 root_cn=None,
+                 root_pw=None,
                  ):
         if SlapdObject._log is None:
             SlapdObject._log = combined_logger('python-ldap-test', log_level=log_level)
 
         if openldap_schema_files is not None:
             self.openldap_schema_files = openldap_schema_files
+
+        if database is not None:
+            self.database = database
+
+        if suffix is not None:
+            self.suffix = suffix
+
+        if root_cn is not None:
+            self.root_cn = root_cn
+
+        if root_pw is not None:
+            self.root_pw = root_pw
 
         self._proc = None
         self._port = port or self._avail_tcp_port()

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -125,7 +125,7 @@ def _add_sbin(path):
 
 def combined_logger(
         log_name,
-        log_level,
+        log_level=logging.WARN,
         sys_log_format='%(levelname)s %(message)s',
         console_log_format='%(asctime)s %(levelname)s %(message)s',
     ):
@@ -235,8 +235,8 @@ class SlapdObject(object):
                  root_pw=None,
                  datadir_prefix=None,
                  ):
-        if SlapdObject._log is None:
-            SlapdObject._log = combined_logger('python-ldap-test', log_level=log_level)
+        if self._log is None:
+            self._log = combined_logger('python-ldap-test', log_level=log_level)
 
         if openldap_schema_files is not None:
             self.openldap_schema_files = openldap_schema_files

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -186,6 +186,15 @@ class SlapdObject(object):
     :param log_level: The verbosity of SlapdObject..
         The default value is `logging.WARNING`.
 
+    :param suffix: The LDAP suffix for all objects. The default is
+        `dc=slapd-test,dc=python-ldap,dc=org`.
+
+    :param root_cn: The root user common name. The default value is `Manager`.
+
+    :param root_pw: The root user password. The default value is `password`.
+
+    :param datadir_prefix: The prefix of the temporary directory where the slapd
+        configuration and data will be stored. The default value is `python-ldap-test`.
 
     .. versionchanged:: 3.1
 

--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -233,6 +233,7 @@ class SlapdObject(object):
                  suffix=None,
                  root_cn=None,
                  root_pw=None,
+                 datadir_prefix=None,
                  ):
         if SlapdObject._log is None:
             SlapdObject._log = combined_logger('python-ldap-test', log_level=log_level)
@@ -255,7 +256,7 @@ class SlapdObject(object):
         self._proc = None
         self._port = port or self._avail_tcp_port()
         self.server_id = self._port % 4096
-        self.testrundir = os.path.join(self.TMPDIR, 'python-ldap-test-%d' % self._port)
+        self.testrundir = os.path.join(self.TMPDIR, '%s-%d' % (datadir_prefix or "python-ldap-test", self._port))
         self._slapd_conf = os.path.join(self.testrundir, 'slapd.d')
         self._db_directory = os.path.join(self.testrundir, "openldap-data")
         self.ldap_uri = "ldap://%s:%d/" % (host or self.local_host, self._port)


### PR DESCRIPTION
A minor improvement for SlapdObject for cases we do want to specify:
- host 
- port

Also, those parameters can be passed to `SlapdObject.__init__` so we do not have to build a class that inherits from SlapObject just to configure this:
- log_level
- initial schemas
- database type
- suffix
- admin cn
- admin password