### PR TITLE
ppolicy control documentation

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -33,6 +33,7 @@ from ldap import __version__
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
+    'sphinx.ext.napoleon',
 ]
 
 try:

--- a/Doc/reference/ldap-controls.rst
+++ b/Doc/reference/ldap-controls.rst
@@ -206,3 +206,16 @@ search.
 
 .. autoclass:: ldap.controls.readentry.PostReadControl
    :members:
+
+
+:py:mod:`ldap.controls.ppolicy` Password Policy Control
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. seealso::
+   `draft-behera-ldap-password-policy <https://tools.ietf.org/html/draft-behera-ldap-password-policy>`_
+
+.. py:module:: ldap.controls.ppolicy
+   :synopsis: passworld policies
+
+.. autoclass:: ldap.controls.ppolicy.PasswordPolicyControl
+   :members:

--- a/Lib/ldap/controls/ppolicy.py
+++ b/Lib/ldap/controls/ppolicy.py
@@ -62,17 +62,31 @@ class PasswordPolicyResponseValue(univ.Sequence):
 
 
 class PasswordPolicyControl(ValueLessRequestControl,ResponseControl):
+  """
+  Indicates the errors and warnings about the password policy.
+
+  Attributes
+  ----------
+
+  timeBeforeExpiration : int
+      The time before the password expires.
+
+  graceAuthNsRemaining : int
+      The number of grace authentications remaining.
+
+  error: int
+      The password and authentication errors.
+  """
   controlType = '1.3.6.1.4.1.42.2.27.8.5.1'
 
   def __init__(self,criticality=False):
     self.criticality = criticality
-
-  def decodeControlValue(self,encodedControlValue):
-    ppolicyValue,_ = decoder.decode(encodedControlValue,asn1Spec=PasswordPolicyResponseValue())
     self.timeBeforeExpiration = None
     self.graceAuthNsRemaining = None
     self.error = None
 
+  def decodeControlValue(self,encodedControlValue):
+    ppolicyValue,_ = decoder.decode(encodedControlValue,asn1Spec=PasswordPolicyResponseValue())
     warning = ppolicyValue.getComponentByName('warning')
     if warning.hasValue():
       if 'timeBeforeExpiration' in warning:


### PR DESCRIPTION
I just noticed that the `ppolicy` control did not appear in the documentation.

Attributes are auto-documented with [sphinx autoattribute](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-autoattribute)

> For module data members and class attributes, documentation can either be put into a comment [...] or in **a docstring after the definition**.