### PR TITLE
Issue #399: do not decode attribute values of post read control

### DIFF
--- a/Doc/reference/ldap-controls.rst
+++ b/Doc/reference/ldap-controls.rst
@@ -197,6 +197,9 @@ search.
 
    :rfc:`4527` - Lightweight Directory Access Protocol (LDAP): Read Entry Controls
 
+.. versionchanged:: 4.0
+   The attribute values of the entry now consists of `bytes` instead of ISO8859-1 decoded `str`.
+
 
 .. autoclass:: ldap.controls.readentry.ReadEntryControl
    :members:

--- a/Lib/ldap/controls/readentry.py
+++ b/Lib/ldap/controls/readentry.py
@@ -42,7 +42,7 @@ class ReadEntryControl(LDAPControl):
     self.dn = str(decodedEntry[0])
     self.entry = {}
     for attr in decodedEntry[1]:
-      self.entry[str(attr[0])] = [ str(attr_value) for attr_value in attr[1] ]
+      self.entry[str(attr[0])] = [ bytes(attr_value) for attr_value in attr[1] ]
 
 
 class PreReadControl(ReadEntryControl):

--- a/Tests/t_ldap_controls_readentry.py
+++ b/Tests/t_ldap_controls_readentry.py
@@ -1,0 +1,28 @@
+import os
+import unittest
+
+# Switch off processing .ldaprc or ldap.conf before importing _ldap
+os.environ['LDAPNOINIT'] = '1'
+
+from ldap.controls import readentry  # noqa: E402
+
+
+PRC_ENC = b'db\x04)uid=Administrator,cn=users,l=school,l=dev0503\x04\tentryUUID1&\x04$5d96cc2c-8e13-103a-8ca5-2f74868e0e44'
+PRC_DEC = b'0\x0b\x04\tentryUUID'
+
+
+class TestLibldapControls(unittest.TestCase):
+
+    def test_pagedresults_encode(self):
+        pr = readentry.PostReadControl(True, ['entryUUID'])
+        self.assertEqual(pr.encodeControlValue(), PRC_DEC)
+
+    def test_readentry_decode(self):
+        pr = readentry.PostReadControl(True, ['entryUUID'])
+        pr.decodeControlValue(PRC_ENC)
+        self.assertIsInstance(pr.dn, str)
+        self.assertEqual(pr.entry, {'entryUUID': [b'5d96cc2c-8e13-103a-8ca5-2f74868e0e44']})
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
leave them bytes, as it's normal for attribute values.