### PR TITLE
Add note to FAQ regarding search referrals

### DIFF
--- a/Doc/faq.rst
+++ b/Doc/faq.rst
@@ -65,6 +65,10 @@ connection.”* Alternatively, a Samba 4 AD returns the diagnostic message
       l = ldap.initialize('ldap://foobar')
       l.set_option(ldap.OPT_REFERRALS,0)
 
+    Note that setting the above option does NOT prevent search continuations
+    from being returned, rather only that ``libldap`` won't attempt to resolve
+    referrals.
+
 **Q**: Why am I seeing a ``ldap.SUCCESS`` traceback as output?
 
     **A**: Most likely, you are using one of the non-synchronous calls, and probably


### PR DESCRIPTION
Several posts across the web in regards to this issue, so an additional
note in the answer to this question seems warranted.

Basing this answer on message this message in the mailing list:
https://mail.python.org/pipermail/python-ldap/2014q1/003350.html

Can client code safely assume that a DN of `None` is always a search referral, because that is what I took from the message linked above?