### PR TITLE
Use slapd.Slapd instead of SlapdObject in unit tests

### DIFF
--- a/Lib/slapdtest/_slapdtest.py
+++ b/Lib/slapdtest/_slapdtest.py
@@ -10,6 +10,7 @@ import time
 import subprocess
 import logging
 import atexit
+import slapd
 from logging.handlers import SysLogHandler
 import unittest
 from shutil import which
@@ -584,7 +585,7 @@ class SlapdTestCase(unittest.TestCase):
     test class which also clones or initializes a running slapd
     """
 
-    server_class = SlapdObject
+    server_class = slapd.Slapd
     server = None
     ldap_object_class = None
 

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -30,7 +30,7 @@ class TestLdapCExtension(SlapdTestCase):
         super().setUpClass()
         # add two initial objects after server was started and is still empty
         suffix_dc = cls.server.suffix.split(',')[0][3:]
-        cls.server._log.debug(
+        cls.server.logger.debug(
             "adding %s and %s",
             cls.server.suffix,
             cls.server.root_dn,
@@ -96,7 +96,7 @@ class TestLdapCExtension(SlapdTestCase):
     @contextlib.contextmanager
     def _open_conn_fd(self, bind=True):
         sock = socket.create_connection(
-            (self.server.hostname, self.server.port)
+            (self.server.host, self.server.port)
         )
         try:
             l = _ldap.initialize_fd(sock.fileno(), self.server.ldap_uri)

--- a/Tests/t_ldap_syncrepl.py
+++ b/Tests/t_ldap_syncrepl.py
@@ -7,6 +7,7 @@ import os
 import shelve
 import unittest
 import binascii
+import slapd
 
 # Switch off processing .ldaprc or ldap.conf before importing _ldap
 os.environ['LDAPNOINIT'] = '1'
@@ -15,14 +16,14 @@ import ldap
 from ldap.ldapobject import SimpleLDAPObject
 from ldap.syncrepl import SyncreplConsumer, SyncInfoMessage
 
-from slapdtest import SlapdObject, SlapdTestCase
+from slapdtest import SlapdTestCase
 
 # a template string for generating simple slapd.conf file
 SLAPD_CONF_PROVIDER_TEMPLATE = r"""dn: cn=config
 objectClass: olcGlobal
 cn: config
 olcServerID: %(serverid)s
-olcLogLevel: %(loglevel)s
+olcLogLevel: stats stats2
 olcAllows: bind_v2
 olcAuthzRegexp: {0}"gidnumber=%(root_gid)s\+uidnumber=%(root_uid)s,cn=peercred,cn=external,cn=auth" "%(rootdn)s"
 olcAuthzRegexp: {1}"C=DE, O=python-ldap, OU=slapd-test, CN=([A-Za-z]+)" "ldap://ou=people,dc=local???($1)"
@@ -128,8 +129,10 @@ LDAP_ENTRIES = {
 }
 
 
-class SyncreplProvider(SlapdObject):
-    slapd_conf_template = SLAPD_CONF_PROVIDER_TEMPLATE
+class SyncreplProvider(slapd.Slapd):
+    def __init__(self, *args, **kwargs):
+        kwargs["configuration_template"] = SLAPD_CONF_PROVIDER_TEMPLATE
+        super().__init__(*args, **kwargs)
 
 
 class SyncreplClient(SimpleLDAPObject, SyncreplConsumer):

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -592,7 +592,7 @@ class Test03_SimpleLDAPObjectWithFileno(Test00_SimpleLDAPObject):
         if hasattr(self, '_sock'):
             raise RuntimeError("socket already connected")
         self._sock = socket.create_connection(
-            (self.server.hostname, self.server.port)
+            (self.server.host, self.server.port)
         )
         return super()._open_ldap_conn(
             who=who, cred=cred, fileno=self._sock.fileno(), **kwargs

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist = py36,py37,py38,py39,py3-nosasltls,doc,py3-trace
 minver = 1.8
 
 [testenv]
-deps =
+deps = slapd
 passenv = WITH_GCOV
 # - Enable BytesWarning
 # - Turn all warnings into exceptions.
@@ -65,7 +65,7 @@ commands =
 
 [testenv:pypy3]
 basepython = pypy3
-deps = pytest
+deps = pytest slapd
 commands = {envpython} -m pytest {posargs}
 
 [testenv:doc]
@@ -73,6 +73,7 @@ basepython = python3
 deps =
     docutils
     markdown
+    slapd
     sphinx
     sphinxcontrib-spelling
 commands =


### PR DESCRIPTION
Fixes #203
All the tests run with [python-slapd](https://github.com/python-ldap/python-slapd) instead of `slapdtest.SlapdObject`.