### PR TITLE
Clean up tox environments & run tox on Fedora in CI 

### DIFF
--- a/.github/workflows/tox-fedora.yml
+++ b/.github/workflows/tox-fedora.yml
@@ -1,0 +1,34 @@
+on: [push, pull_request]
+
+name: Tox on Fedora
+
+jobs:
+  tox_test:
+    name: Tox env "${{matrix.tox_env}}" on Fedora
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run Tox tests
+      uses: fedora-python/tox-github-action@master
+      with:
+        tox_env: ${{ matrix.tox_env }}
+        dnf_install: >
+            @c-development openldap-devel python3-devel
+            openldap-servers openldap-clients lcov clang-analyzer valgrind
+            enchant
+    strategy:
+      matrix:
+        tox_env:
+        - py36
+        - py37
+        - py38
+        - py39
+        - py310
+        - c90-py36
+        - c90-py37
+        - py3-nosasltls
+        - py3-trace
+        - pypy3
+        - doc
+
+    # Use GitHub's Linux Docker host
+    runs-on: ubuntu-latest

--- a/Doc/installing.rst
+++ b/Doc/installing.rst
@@ -130,7 +130,7 @@ Alpine
 
 Packages for building::
 
-    # apk add build-base openldap-dev python2-dev python3-dev
+    # apk add build-base openldap-dev python3-dev
 
 CentOS
 ------
@@ -145,12 +145,12 @@ Debian
 
 Packages for building and testing::
 
-   # apt-get install build-essential python3-dev python2.7-dev \
+   # apt-get install build-essential python3-dev \
        libldap2-dev libsasl2-dev slapd ldap-utils tox \
        lcov valgrind
-       
+
 .. note::
-   
+
    On older releases ``tox`` was called ``python-tox``.
 
 Fedora
@@ -159,7 +159,7 @@ Fedora
 Packages for building and testing::
 
    # dnf install "@C Development Tools and Libraries" openldap-devel \
-       python2-devel python3-devel python3-tox \
+       python3-devel python3-tox \
        lcov clang-analyzer valgrind
 
 .. note::

--- a/Doc/sample_workflow.rst
+++ b/Doc/sample_workflow.rst
@@ -61,15 +61,15 @@ This will run tests on all supported versions of Python that you have
 installed, skipping the ones you don't.
 To run a subset of test environments, run for example::
 
-    (__venv__)$ tox -e py27,py36
+    (__venv__)$ tox -e py36,py39
 
 In addition to ``pyXY`` environments, we have extra environments
 for checking things independent of the Python version:
 
 * ``doc`` checks syntax and spelling of the documentation
 * ``coverage-report`` generates a test coverage report for Python code.
-  It must be used last, e.g. ``tox -e py27,py36,coverage-report``.
-* ``py2-nosasltls`` and ``py3-nosasltls`` check functionality without
+  It must be used last, e.g. ``tox -e py36,py39,coverage-report``.
+* ``py3-nosasltls`` check functionality without
   SASL and TLS bindings compiled in.
 
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ lcov-clean:
 	if [ -d build ]; then find build -name '*.gc??' -delete; fi
 
 lcov-coverage:
-	WITH_GCOV=1 tox -e py27,py36
+	WITH_GCOV=1 tox -e py36
 
 $(LCOV_INFO): build
 	lcov --capture --directory build --output-file $(LCOV_INFO)

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
-    # Note: when updating Python versions, also change .travis.yml and tox.ini
+    # Note: when updating Python versions, also change tox.ini and .github/workflows/*
 
     'Topic :: Database',
     'Topic :: Internet',

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # Note: when updating Python versions, also change setup.py and .github/worlflows/*
-envlist = py{36,37,38,39},c90-py{36,37},py3-nosasltls,doc,py3-trace
+envlist = py{36,37,38,39,310},c90-py{36,37},py3-nosasltls,doc,py3-trace
 minver = 1.8
 
 [gh-actions]

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@
 # and then run "tox" from this directory.
 
 [tox]
-# Note: when updating Python versions, also change setup.py and .travis.yml
-envlist = py36,py37,py38,py39,py3-nosasltls,doc,py3-trace
+# Note: when updating Python versions, also change setup.py and .github/worlflows/*
+envlist = py{36,37,38,39},c90-py{36,37},py3-nosasltls,doc,py3-trace
 minver = 1.8
 
 [gh-actions]
@@ -21,6 +21,8 @@ deps =
 passenv = WITH_GCOV
 # - Enable BytesWarning
 # - Turn all warnings into exceptions.
+setenv =
+    CFLAGS=-Wno-int-in-bool-context -Werror -Werror=declaration-after-statement -std=c99
 commands = {envpython} -bb -Werror \
     -m unittest discover -v -s Tests -p 't_*' {posargs}
 
@@ -50,6 +52,11 @@ setenv =
     PYTHON_LDAP_TRACE_LEVEL=9
     PYTHON_LDAP_TRACE_FILE={envtmpdir}/trace.log
 commands = {[testenv]commands}
+
+[testenv:c90]
+setenv =
+    CFLAGS=-Wno-int-in-bool-context -Werror -Werror=declaration-after-statement -std=c90
+commands = {envpython} -Werror -c "import ldap" # we just test compilation here
 
 [testenv:macos]
 # Travis CI macOS image does not have slapd

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # Note: when updating Python versions, also change setup.py and .github/worlflows/*
-envlist = py{36,37,38,39,310},c90-py{36,37},py3-nosasltls,doc,py3-trace
+envlist = py{36,37,38,39,310},c90-py{36,37},py3-nosasltls,doc,py3-trace,pypy3
 minver = 1.8
 
 [gh-actions]


### PR DESCRIPTION
- Add CFLAGS used on Travis CI (`-Werror`, `std=c99` and similar) to tox environments
- Add `std=c90` environments for Python versions that compile with c90
- Add an environment for pypy3 and for Python 3.10 (a bit early, but unlikely to break now)
- Some general clean-up (remove python2 remnants, fix comments)
- Add tox-on-Fedora runs to the CI

Partially addresses: https://github.com/python-ldap/python-ldap/issues/418

~~The actions might not run on the PR that adds them, but they passed here: https://github.com/encukou/python-ldap/actions/runs/983127874~~