### PR TITLE
Add OPT_X_TLS_REQUIRE_SAN

### DIFF
--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -346,6 +346,29 @@ TLS options
    :py:const:`OPT_X_TLS_HARD`
       Same as :py:const:`OPT_X_TLS_DEMAND`
 
+.. py:data:: OPT_X_TLS_REQUIRE_SAN
+
+   get/set how OpenLDAP validates subject alternative name extension,
+   available in OpenSSL 2.4.52 and newer.
+
+   :py:const:`OPT_X_TLS_NEVER`
+      Don't check SAN
+
+   :py:const:`OPT_X_TLS_ALLOW`
+      Check SAN first, always fall back to subject common name (default)
+
+   :py:const:`OPT_X_TLS_TRY`
+      Check SAN first, only fall back to subject common name, when no SAN
+      extension is present (:rfc:`6125` conform validation)
+
+   :py:const:`OPT_X_TLS_DEMAND`
+      Validate peer cert chain and host name
+
+   :py:const:`OPT_X_TLS_HARD`
+      Require SAN, don't fall back to subject common name
+
+   .. versionadded:: 3.4.0
+
 .. py:data:: OPT_X_TLS_ALLOW
 
    Value for :py:const:`OPT_X_TLS_REQUIRE_CERT`

--- a/Lib/ldap/constants.py
+++ b/Lib/ldap/constants.py
@@ -298,6 +298,9 @@ CONSTANTS = (
     TLSInt('OPT_X_TLS_PROTOCOL_MIN', optional=True),
     TLSInt('OPT_X_TLS_PACKAGE', optional=True),
 
+    # Added in OpenLDAP 2.4.52
+    TLSInt('OPT_X_TLS_REQUIRE_SAN', optional=True),
+
     Int('OPT_X_SASL_MECH'),
     Int('OPT_X_SASL_REALM'),
     Int('OPT_X_SASL_AUTHCID'),

--- a/Modules/constants_generated.h
+++ b/Modules/constants_generated.h
@@ -249,6 +249,10 @@ add_int(OPT_X_TLS_PROTOCOL_MIN);
 add_int(OPT_X_TLS_PACKAGE);
 #endif
 
+#if defined(LDAP_OPT_X_TLS_REQUIRE_SAN)
+add_int(OPT_X_TLS_REQUIRE_SAN);
+#endif
+
 #endif
 
 add_int(OPT_X_SASL_MECH);

--- a/Modules/options.c
+++ b/Modules/options.c
@@ -88,6 +88,9 @@ LDAP_set_option(LDAPObject *self, int option, PyObject *value)
 #ifdef LDAP_OPT_X_TLS_PROTOCOL_MIN
     case LDAP_OPT_X_TLS_PROTOCOL_MIN:
 #endif
+#ifdef LDAP_OPT_X_TLS_REQUIRE_SAN
+    case LDAP_OPT_X_TLS_REQUIRE_SAN:
+#endif
 #endif
 #ifdef HAVE_SASL
     case LDAP_OPT_X_SASL_SSF_MIN:
@@ -297,6 +300,9 @@ LDAP_get_option(LDAPObject *self, int option)
 #endif
 #ifdef LDAP_OPT_X_TLS_PROTOCOL_MIN
     case LDAP_OPT_X_TLS_PROTOCOL_MIN:
+#endif
+#ifdef LDAP_OPT_X_TLS_REQUIRE_SAN
+    case LDAP_OPT_X_TLS_REQUIRE_SAN:
 #endif
 #endif
 #ifdef HAVE_SASL

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -932,6 +932,29 @@ class TestLdapCExtension(SlapdTestCase):
         package = _ldap.get_option(_ldap.OPT_X_TLS_PACKAGE)
         self.assertIn(package, {"GnuTLS", "MozNSS", "OpenSSL"})
 
+    @unittest.skipUnless(
+        hasattr(_ldap, "OPT_X_TLS_REQUIRE_SAN"),
+        reason="Test requires OPT_X_TLS_REQUIRE_SAN"
+    )
+    def test_require_san(self):
+        l = self._open_conn(bind=False)
+        value = l.get_option(_ldap.OPT_X_TLS_REQUIRE_SAN)
+        self.assertIn(
+            value,
+            {
+                _ldap.OPT_X_TLS_NEVER,
+                _ldap.OPT_X_TLS_ALLOW,
+                _ldap.OPT_X_TLS_TRY,
+                _ldap.OPT_X_TLS_DEMAND,
+                _ldap.OPT_X_TLS_HARD,
+            }
+        )
+        l.set_option(_ldap.OPT_X_TLS_REQUIRE_SAN, _ldap.OPT_X_TLS_TRY)
+        self.assertEqual(
+            l.get_option(_ldap.OPT_X_TLS_REQUIRE_SAN),
+            _ldap.OPT_X_TLS_TRY
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add bindings for OPT_X_TLS_REQUIRE_SAN option. The flag was introduced
in OpenLDAP 2.4.52 to configure subject alternative name verification.

Signed-off-by: Christian Heimes <cheimes@redhat.com>