### PR TITLE
Support OPT_X_TLS_PEERCERT

### DIFF
--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -406,7 +406,12 @@ TLS options
 
 .. py:data:: OPT_X_TLS_PEERCERT
 
-   Get peer's certificate as binary ASN.1 data structure (not supported)
+   Get peer's certificate as binary ASN.1 data structure (DER)
+
+   .. versionadded:: 3.4.0
+
+   .. note::
+      The option leaks memory with OpenLDAP < 2.5.8.
 
 .. py:data:: OPT_X_TLS_PROTOCOL_MIN
 


### PR DESCRIPTION
Replaces PR https://github.com/python-ldap/python-ldap/pull/401