### PR TITLE
Implement OPT_X_SASL_SSF_EXTERNAL setter

### DIFF
--- a/Modules/options.c
+++ b/Modules/options.c
@@ -115,6 +115,7 @@ LDAP_set_option(LDAPObject *self, int option, PyObject *value)
 #ifdef HAVE_SASL
     case LDAP_OPT_X_SASL_SSF_MIN:
     case LDAP_OPT_X_SASL_SSF_MAX:
+    case LDAP_OPT_X_SASL_SSF_EXTERNAL:
         if (!PyArg_Parse(value, "k:set_option", &blen))
             return 0;
         ptr = &blen;
@@ -261,6 +262,12 @@ LDAP_get_option(LDAPObject *self, int option)
     Py_ssize_t i, num_extensions;
 
     switch (option) {
+#ifdef HAVE_SASL
+    case LDAP_OPT_X_SASL_SSF_EXTERNAL:
+        /* Write-only options */
+        PyErr_SetString(PyExc_ValueError, "write-only option");
+        return NULL;
+#endif
     case LDAP_OPT_API_INFO:
         apiinfo.ldapai_info_version = LDAP_API_INFO_VERSION;
         res = LDAP_int_get_option(self, option, &apiinfo);

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -362,6 +362,9 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
         self.assertEqual(l.get_option(ldap.OPT_X_SASL_SSF_MAX), 256)
 
         l.sasl_external_bind_s()
+        with self.assertRaisesRegex(ValueError, "write-only option"):
+            l.get_option(ldap.OPT_X_SASL_SSF_EXTERNAL)
+        l.set_option(ldap.OPT_X_SASL_SSF_EXTERNAL, 256)
         self.assertEqual(l.whoami_s(), 'dn:' + self.server.root_dn.lower())
 
     def test007_timeout(self):


### PR DESCRIPTION
The option flag ``OPT_X_SASL_SSF_EXTERNAL`` never worked because the
set_option code didn't handle the flag correctly.

Fixes: https://github.com/python-ldap/python-ldap/issues/423
Signed-off-by: Christian Heimes <cheimes@redhat.com>