### PR TITLE
Handle unknown LDAP result code

### DIFF
--- a/Modules/constants.c
+++ b/Modules/constants.c
@@ -31,7 +31,8 @@ static PyObject *errobjects[LDAP_ERROR_MAX - LDAP_ERROR_MIN + 1];
 PyObject *
 LDAPerr(int errnum)
 {
-    if (errnum >= LDAP_ERROR_MIN && errnum <= LDAP_ERROR_MAX) {
+    if (errnum >= LDAP_ERROR_MIN && errnum <= LDAP_ERROR_MAX &&
+            errobjects[errnum + LDAP_ERROR_OFFSET] != NULL) {
         PyErr_SetNone(errobjects[errnum + LDAP_ERROR_OFFSET]);
     }
     else {
@@ -88,10 +89,13 @@ LDAPraise_for_message(LDAP *l, LDAPMessage *m)
             ldap_get_option(l, LDAP_OPT_ERROR_STRING, &error);
         }
 
-        if (errnum >= LDAP_ERROR_MIN && errnum <= LDAP_ERROR_MAX)
+        if (errnum >= LDAP_ERROR_MIN && errnum <= LDAP_ERROR_MAX &&
+                errobjects[errnum + LDAP_ERROR_OFFSET] != NULL) {
             errobj = errobjects[errnum + LDAP_ERROR_OFFSET];
-        else
+        }
+        else {
             errobj = LDAPexception_class;
+        }
 
         info = PyDict_New();
         if (info == NULL) {


### PR DESCRIPTION
Prevent ``SystemError: error return without exception set`` when LDAP
server returns an unknown LDAP result code.

Fixes: https://github.com/python-ldap/python-ldap/issues/240
Signed-off-by: Christian Heimes <cheimes@redhat.com>