### PR TITLE
Release 3.4.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-Released 3.4.0 2021-09-17
+Released 3.4.0 2021-11-26
 
 This release requires Python 3.6 or above,
 and is tested with Python 3.6 to 3.10.

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,48 @@
+Released 3.4.0 2021-09-17
+
+This release requires Python 3.6 or above,
+and is tested with Python 3.6 to 3.10.
+Python 2 is no longer supported.
+
+New code in the python-ldap project is available under the MIT licence
+(available in ``LICENCE.MIT`` in the source). Several contributors have agreed
+to apply this licence their previous contributions as well.
+See the ``README`` for details.
+
+The following undocumented functions are deprecated and scheduled for removal:
+- ``ldap.cidict.strlist_intersection``
+- ``ldap.cidict.strlist_minus``
+- ``ldap.cidict.strlist_union``
+
+Changes:
+* On MacOS, remove option to make LDAP connections from a file descriptor
+  when built with the system libldap (which lacks the underlying function,
+  ``ldap_init_fd``)
+* Attribute values of the post read control are now ``bytes``
+  instead of ISO8859-1 decoded ``str``
+* ``LDAPUrl`` now treats urlscheme as case-insensitive
+* Several OpenLDAP options are now supported:
+  * ``OPT_X_TLS_REQUIRE_SAN``
+  * ``OPT_X_SASL_SSF_EXTERNAL``
+  * ``OPT_X_TLS_PEERCERT``
+
+Fixes:
+* The ``copy()`` method of ``cidict`` was added back. It was unintentionally
+  removed in 3.3.0
+* Fixed getting/setting ``SASL`` options on big endian platforms
+* Unknown LDAP result code are now converted to ``LDAPexception``,
+  rather than raising a ``SystemError``.
+
+slapdtest:
+* Show stderr of slapd -Ttest
+* ``SlapdObject`` uses directory-based configuration of ``slapd``
+* ``SlapdObject`` startup is now faster
+
+Infrastructure:
+* CI now runs on GitHub Actions rather than Travis CI.
+
+
+----------------------------------------------------------------
 Released 3.3.0 2020-06-18
 
 Highlights:

--- a/Doc/installing.rst
+++ b/Doc/installing.rst
@@ -111,7 +111,7 @@ Build prerequisites
 The following software packages are required to be installed
 on the local system when building python-ldap:
 
-- `Python`_ version 2.7, or 3.4 or later including its development files
+- `Python`_ including its development files
 - C compiler corresponding to your Python version (on Linux, it is usually ``gcc``)
 - `OpenLDAP`_ client libs version 2.4.11 or later;
   it is not possible and not supported to build with prior versions.

--- a/Lib/ldap/cidict.py
+++ b/Lib/ldap/cidict.py
@@ -85,7 +85,7 @@ def strlist_minus(a,b):
   a,b are supposed to be lists of case-insensitive strings.
   """
   warnings.warn(
-    "strlist functions are deprecated and will be removed in 3.4",
+    "strlist functions are deprecated and will be removed in 3.5",
     category=DeprecationWarning,
     stacklevel=2,
   )
@@ -105,7 +105,7 @@ def strlist_intersection(a,b):
   Return intersection of two lists of case-insensitive strings a,b.
   """
   warnings.warn(
-    "strlist functions are deprecated and will be removed in 3.4",
+    "strlist functions are deprecated and will be removed in 3.5",
     category=DeprecationWarning,
     stacklevel=2,
   )
@@ -125,7 +125,7 @@ def strlist_union(a,b):
   Return union of two lists of case-insensitive strings a,b.
   """
   warnings.warn(
-    "strlist functions are deprecated and will be removed in 3.4",
+    "strlist functions are deprecated and will be removed in 3.5",
     category=DeprecationWarning,
     stacklevel=2,
   )

--- a/Lib/ldap/pkginfo.py
+++ b/Lib/ldap/pkginfo.py
@@ -1,6 +1,6 @@
 """
 meta attributes for packaging which does not import any dependencies
 """
-__version__ = '3.3.0'
+__version__ = '3.4.0'
 __author__ = 'python-ldap project'
 __license__ = 'Python style'

--- a/Lib/ldapurl.py
+++ b/Lib/ldapurl.py
@@ -4,7 +4,7 @@ ldapurl - handling of LDAP URLs as described in RFC 4516
 See https://www.python-ldap.org/ for details.
 """
 
-__version__ = '3.3.0'
+__version__ = '3.4.0'
 
 __all__ = [
   # constants

--- a/Lib/ldif.py
+++ b/Lib/ldif.py
@@ -3,7 +3,7 @@ ldif - generate and parse LDIF data (see RFC 2849)
 
 See https://www.python-ldap.org/ for details.
 """
-__version__ = '3.3.0'
+__version__ = '3.4.0'
 
 __all__ = [
   # constants

--- a/Lib/slapdtest/__init__.py
+++ b/Lib/slapdtest/__init__.py
@@ -4,7 +4,7 @@ slapdtest - module for spawning test instances of OpenLDAP's slapd server
 See https://www.python-ldap.org/ for details.
 """
 
-__version__ = '3.3.0'
+__version__ = '3.4.0'
 
 from slapdtest._slapdtest import SlapdObject, SlapdTestCase, SysLogHandler
 from slapdtest._slapdtest import requires_ldapi, requires_sasl, requires_tls


### PR DESCRIPTION
I would like to release soon. The following fixes might go in before the release: 
* [ ] https://github.com/python-ldap/python-ldap/pull/427
* [ ] https://github.com/python-ldap/python-ldap/pull/350
* [ ] https://github.com/python-ldap/python-ldap/pull/341
* [ ] GHSL-2021-117

After the release:
* [ ] Add a new maintainer
* [ ] Remove the deprecated `strlist` functions