### PR TITLE
Fix wrong asserts in test_test_flags

### DIFF
--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -234,11 +234,11 @@ class TestLdapCExtension(SlapdTestCase):
         if 'TLS' in disabled:
             self.assertFalse(_ldap.TLS_AVAIL)
         else:
-            self.assertFalse(_ldap.TLS_AVAIL)
+            self.assertTrue(_ldap.TLS_AVAIL)
         if 'SASL' in disabled:
             self.assertFalse(_ldap.SASL_AVAIL)
         else:
-            self.assertFalse(_ldap.SASL_AVAIL)
+            self.assertTrue(_ldap.SASL_AVAIL)
 
     def test_simple_bind(self):
         l = self._open_conn()


### PR DESCRIPTION
Introduced in c5ad8025632fb5e5e84cced5a0f8c7ddda1e8dae

These conditions are redundant now, so I assume it’s a mistake.