### PR TITLE
Fix inefficient regular expression in the schema tokenizer

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -14,6 +14,11 @@ The following undocumented functions are deprecated and scheduled for removal:
 - ``ldap.cidict.strlist_minus``
 - ``ldap.cidict.strlist_union``
 
+Security fixes:
+* Fix inefficient regular expression which allows denial-of-service attacks
+  when parsing specially-crafted LDAP schema.
+  (GHSL-2021-117)
+
 Changes:
 * On MacOS, remove option to make LDAP connections from a file descriptor
   when built with the system libldap (which lacks the underlying function,

--- a/Lib/ldap/schema/tokenizer.py
+++ b/Lib/ldap/schema/tokenizer.py
@@ -13,7 +13,7 @@ TOKENS_FINDALL = re.compile(
     r"|"              # or
     r"([^'$()\s]+)"   # string of length >= 1 without '$() or whitespace
     r"|"              # or
-    r"('(?:[^'\\]|\\\\|\\.)*?'(?!\w))"
+    r"('(?:[^'\\]|\\.)*'(?!\w))"
                       # any string or empty string surrounded by unescaped
                       # single quotes except if right quote is succeeded by
                       # alphanumeric char


### PR DESCRIPTION
Fixes: GHSL-2021-117
Thank you to GitHub team members @erik-krogh (Erik Krogh
Kristensen) and @yoff (Rasmus Petersen) for discovering the
issue.