### PR TITLE
Add 'referrals' to the LDAPError exception as a list containing all referrals returned from server

### DIFF
--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -577,6 +577,13 @@ The module defines the following exceptions:
      attached to the error.
    * ``'errno'``: the C ``errno``, usually set by system calls or ``libc``
      rather than the LDAP libraries.
+   * ``'referrals'``: list of referrals (LDAP URIs) attached to the error.
+
+.. versionchanged:: 3.5
+
+   Introduced new ``'referrals'`` field. Relying on the first referral being
+   listed in the ``'info'`` field is now deprecated and will go away in the
+   future.
 
 .. py:exception:: ADMINLIMIT_EXCEEDED
 

--- a/Modules/constants.c
+++ b/Modules/constants.c
@@ -165,10 +165,32 @@ LDAPraise_for_message(LDAP *l, LDAPMessage *m)
         if (errnum == LDAP_REFERRAL && refs != NULL && refs[0] != NULL) {
             /* Keep old behaviour, overshadow error message */
             char err[1024];
+            PyObject *referralList;
+            int i;
 
+            for ( i=0; refs[i]; i++ ) /* count */;
+            referralList = PyList_New(i);
+            if (referralList) {
+                for ( ; i--; ) {
+                    PyObject *referralURL = Py_BuildValue("s", refs[i]);
+                    if (referralURL == NULL ||
+                            PyList_SetItem(referralList, i, referralURL)) {
+                        Py_CLEAR(referralList);
+                        break;
+                    }
+                }
+            }
+            if (referralList) {
+                PyDict_SetItemString(info, "referrals", referralList);
+                Py_CLEAR(referralList);
+            }
+
+            /* FIXME: Drop this in 4.0/5.0 + make the "else if" below an "if" */
             snprintf(err, sizeof(err), "Referral:\n%s", refs[0]);
             str = PyUnicode_FromString(err);
-            PyDict_SetItemString(info, "info", str);
+            if (str) {
+                PyDict_SetItemString(info, "info", str);
+            }
             Py_XDECREF(str);
         }
         else if (error != NULL && *error != '\0') {

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -21,6 +21,7 @@ os.environ['LDAPNOINIT'] = '1'
 
 import ldap
 from ldap.ldapobject import SimpleLDAPObject, ReconnectLDAPObject
+from ldap.controls.simple import ManageDSAITControl
 
 from slapdtest import SlapdTestCase
 from slapdtest import requires_ldapi, requires_sasl, requires_tls
@@ -601,6 +602,28 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
                 l.search_ext(
                     "%s" % self.server.suffix, ldap.SCOPE_SUBTREE, attrlist=attrlist
                 )
+
+    def test_referral_error(self):
+        """Tests the case where a modify cannot be serviced as under a
+        referral"""
+        l = self._open_ldap_conn(bytes_mode=False)
+
+        l.set_option(ldap.OPT_REFERRALS, 0)
+        dn = "cn=delegated,ou=Container,%s" % self.server.suffix
+        l.add_s(dn, [
+            ("objectClass", [b'referral', b'extensibleObject']),
+            ("ref", b'ldap://ldap.example.com'),
+        ])
+
+        try:
+            target = f"cn=test,{dn}"
+            with self.assertRaises(ldap.REFERRAL) as e:
+                l.modify_s(target, [])
+            result = e.exception
+            self.assertEqual(result.args[0]['referrals'],
+                             [f'ldap://ldap.example.com/{target}'])
+        finally:
+            l.delete_ext_s(dn, serverctrls=[ManageDSAITControl()])
 
 
 class Test01_ReconnectLDAPObject(Test00_SimpleLDAPObject):


### PR DESCRIPTION
Added a refList that contains all referrals returned from the server.
Still maintains the first referral in 'info'. 