### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,9 @@ setup(
   author = 'python-ldap project',
   author_email = 'python-ldap@python.org',
   url = 'https://www.python-ldap.org/',
+  project_urls = {
+    'Source': 'https://github.com/python-ldap/python-ldap',
+  },
   download_url = 'https://pypi.org/project/python-ldap/',
   classifiers = [
     'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)