### PR TITLE
Allow passing None as uri argument to ldap.initialize()

### DIFF
--- a/Modules/functions.c
+++ b/Modules/functions.c
@@ -17,7 +17,7 @@ l_ldap_initialize(PyObject *unused, PyObject *args)
     int ret;
     PyThreadState *save;
 
-    if (!PyArg_ParseTuple(args, "s:initialize", &uri))
+    if (!PyArg_ParseTuple(args, "z:initialize", &uri))
         return NULL;
 
     save = PyEval_SaveThread();


### PR DESCRIPTION
OpenLDAP allows passing NULL to ldap_initialize(). In this case the
default URI from ldap.conf will be used. Allow passing None as uri
argument to ldap.initialize().