### PR TITLE
Add sldapdtest.certs to setup.py packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -153,6 +153,7 @@ setup(
     'ldap.extop',
     'ldap.schema',
     'slapdtest',
+    'slapdtest.certs',
   ],
   package_dir = {'': 'Lib',},
   data_files = LDAP_CLASS.extra_files,


### PR DESCRIPTION
Add slapdtest.certs to packages, to fix deprecation warning.