### PR TITLE
Add ASN.1 replace to psearch control

### DIFF
--- a/Doc/reference/ldap-controls.rst
+++ b/Doc/reference/ldap-controls.rst
@@ -171,6 +171,7 @@ search.
 .. autoclass:: ldap.controls.psearch.EntryChangeNotificationControl
    :members:
 
+.. |ASN.1| replace:: Asn1Type
 
 :py:mod:`ldap.controls.sessiontrack` Session tracking control
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Doc/reference/ldap-extop.rst
+++ b/Doc/reference/ldap-extop.rst
@@ -38,3 +38,5 @@ This requires :py:mod:`pyasn1` and :py:mod:`pyasn1_modules` to be installed.
 
 .. autoclass:: ldap.extop.dds.RefreshResponse
    :members:
+
+.. |ASN.1| replace:: Asn1Type


### PR DESCRIPTION
Allow Sphinx to pickup the ASN.1 substitution from pyasn1, so docs can build.

I'm not completely sure that this is how Sphinx is suppose to work though. 