### PR TITLE
Fix broken reset and tearDown in pypy3

### DIFF
--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -658,12 +658,12 @@ class Test03_SimpleLDAPObjectWithFileno(Test00_SimpleLDAPObject):
 
     def tearDown(self):
         self._sock.close()
-        del self._sock
+        delattr(self, '_sock')
         super().tearDown()
 
     def reset_connection(self):
         self._sock.close()
-        del self._sock
+        delattr(self, '_sock')
         super(Test03_SimpleLDAPObjectWithFileno, self).reset_connection()
 
 


### PR DESCRIPTION
There appear to be some minor differences in the CPython and Pypy3 implementations of del. 
Use delattr to ensure that hasattr will see the attributes as deleted.

This should fix to of the failing pypy3 test cases.