### PR TITLE
Add Python 3.10 and 3.11 to CI and tox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "pypy3"]
     steps:
       - name: Checkout
         uses: "actions/checkout@v2"

--- a/.github/workflows/tox-fedora.yml
+++ b/.github/workflows/tox-fedora.yml
@@ -23,6 +23,7 @@ jobs:
         - py38
         - py39
         - py310
+        - py311
         - c90-py36
         - c90-py37
         - py3-nosasltls

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,8 @@ setup(
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     # Note: when updating Python versions, also change tox.ini and .github/workflows/*
 
     'Topic :: Database',

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # Note: when updating Python versions, also change setup.py and .github/worlflows/*
-envlist = py{36,37,38,39,310},c90-py{36,37},py3-nosasltls,doc,py3-trace,pypy3
+envlist = py{36,37,38,39,310,311},c90-py{36,37},py3-nosasltls,doc,py3-trace,pypy3
 minver = 1.8
 
 [gh-actions]
@@ -14,6 +14,8 @@ python =
     3.7: py37
     3.8: py38, doc, py3-nosasltls
     3.9: py39, py3-trace
+    3.10: py310
+    3.11: py311
     pypy3: pypy3
 
 [testenv]


### PR DESCRIPTION
Noticed Python 3.10 was missing from GitHub Actions and trove classifiers and 3.11 was missing from those two plus tox.

Stylistic nit: in GHA, quotes are needed around 3.10 in the job matrix because YAML would parse the unquoted version as 3.1, so I went ahead and added quotes around all entries in the `python-version` list for consistency. I can revert this if desired.