### PR TITLE
ci: Update dependency on enchant-2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Install apt dependencies
         run: |
           set -ex
-          sudo apt update
-          sudo apt install -y ldap-utils slapd enchant libldap2-dev libsasl2-dev apparmor-utils
+          sudo apt-get update
+          sudo apt-get install -y ldap-utils slapd enchant-2 libldap2-dev libsasl2-dev apparmor-utils
       - name: Disable AppArmor
         run: sudo aa-disable /usr/sbin/slapd
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
as `enchant` is no longer available in `ubuntu-latest`, which recently switched to Ubuntu-22.04 "jammy". Because of this change to the infrastructure every pipeline if failing, see https://github.com/python-ldap/python-ldap/actions/runs/3911725528/jobs/6772964593#step:3:52 for example.

And also switch from `apt` to `apt-get` as the formers API is not stable yet and currently targeted for interactive use only:

> sudo apt install -y ldap-utils slapd enchant libldap2-dev libsasl2-dev apparmor-utils
...
> WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
...
> E: Unable to locate package enchant