### PR TITLE
Conscious Language: Rename master branch to main branch

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -50,8 +50,8 @@ templates_path = ['.templates']
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# The master toctree document.
-master_doc = 'index'
+# The root toctree document.
+root_doc = 'index'
 
 # General substitutions.
 project = 'python-ldap'

--- a/Doc/faq.rst
+++ b/Doc/faq.rst
@@ -13,7 +13,7 @@ Project
   **A3**: see file CHANGES in source distribution
   or `repository`_.
 
-.. _repository: https://github.com/python-ldap/python-ldap/blob/master/CHANGES
+.. _repository: https://github.com/python-ldap/python-ldap/blob/main/CHANGES
 
 
 Usage


### PR DESCRIPTION
Additionally, rename sphinx configuration parameter master_doc to root_doc

Fixes: https://github.com/python-ldap/python-ldap/issues/509