### PR TITLE
Add retry on EINTR.

### DIFF
--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -31,7 +31,8 @@ from ldap import LDAPError
 from errno import EINTR
 
 def _retry_on_interrupted_ldap_call(func, *args, **kwargs):
-  """Call func, retrying if it raises an LDAPError with errno == EINTR.
+  """
+  Call func, retrying if it raises an LDAPError with errno == EINTR.
   """
 
   attempts = 0
@@ -42,9 +43,13 @@ def _retry_on_interrupted_ldap_call(func, *args, **kwargs):
     except LDAPError as e:
       if attempts > 1:
         raise e
-      if e.args[0]['errno'] == EINTR:
-          time.sleep(0.1)
-          continue
+      try:
+        if 'info' not in e.args[0] and 'errno' in e.args[0]:
+          if e.args[0]['errno'] == EINTR:
+            time.sleep(0.1)
+            continue
+      except IndexError:
+        pass
       raise e
 
 

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -44,14 +44,13 @@ def _retry_on_interrupted_ldap_call(func, *args, **kwargs):
       if attempts > 1:
         raise e
       try:
-        if 'info' not in e.args[0] and 'errno' in e.args[0]:
+        if 'errno' in e.args[0]:
           if e.args[0]['errno'] == EINTR:
             time.sleep(0.1)
             continue
       except IndexError:
         pass
       raise e
-
 
 class LDAPBytesWarning(BytesWarning):
     """Python 2 bytes mode warning"""

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -28,24 +28,7 @@ from ldap.extop import ExtendedRequest,ExtendedResponse,PasswordModifyResponse
 
 from ldap import LDAPError
 
-
-class LDAPBytesWarning(BytesWarning):
-    """Python 2 bytes mode warning"""
-
-    def __init__(self, *args, **kwargs):
-        warnings.warn(
-            "LDAPBytesWarning is deprecated and will be removed in the future",
-            DeprecationWarning,
-        )
-        super().__init__(*args, **kwargs)
-
-
-class NO_UNIQUE_ENTRY(ldap.NO_SUCH_OBJECT):
-  """
-  Exception raised if a LDAP search returned more than entry entry
-  although assumed to return a unique single search result.
-  """
-
+from errno import EINTR
 
 def _retry_on_interrupted_ldap_call(func, *args, **kwargs):
   """Call func, retrying if it raises an LDAPError with errno == EINTR.
@@ -63,6 +46,24 @@ def _retry_on_interrupted_ldap_call(func, *args, **kwargs):
           time.sleep(0.1)
           continue
       raise e
+
+
+class LDAPBytesWarning(BytesWarning):
+    """Python 2 bytes mode warning"""
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "LDAPBytesWarning is deprecated and will be removed in the future",
+            DeprecationWarning,
+        )
+        super().__init__(*args, **kwargs)
+
+
+class NO_UNIQUE_ENTRY(ldap.NO_SUCH_OBJECT):
+  """
+  Exception raised if a LDAP search returned more than entry entry
+  although assumed to return a unique single search result.
+  """
 
 
 class SimpleLDAPObject:

--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -144,7 +144,7 @@ class SimpleLDAPObject:
     diagnostic_message_success = None
     try:
       try:
-        result = _retry_on_interrupted_ldap_call(*args,**kwargs)
+        result = _retry_on_interrupted_ldap_call(func,*args,**kwargs)
         if __debug__ and self._trace_level>=2:
           if func.__name__!="unbind_ext":
             diagnostic_message_success = self._l.get_option(ldap.OPT_DIAGNOSTIC_MESSAGE)


### PR DESCRIPTION
Try and fix issue #242 by adding a retry on EINTR and a sleep before attempting to do so. This is based off of https://github.com/python-ldap/python-ldap/pull/291. 
We happen to come across a few instances of EINTR in our usage every day and would like to add a single retry since it seems all further LDAP calls are successful. Only kept it to a single retry for now, though I could be convinced to raise it.