### PR TITLE
Fix filter string error

### DIFF
--- a/Lib/ldap/filter.py
+++ b/Lib/ldap/filter.py
@@ -38,7 +38,7 @@ def escape_filter_chars(assertion_value,escape_mode=0):
       raise ValueError('escape_mode must be 0, 1 or 2.')
     s = ''.join(r)
   else:
-    s = assertion_value.replace('\\', r'\5c')
+    s = str(assertion_value).replace('\\', r'\5c')
     s = s.replace(r'*', r'\2a')
     s = s.replace(r'(', r'\28')
     s = s.replace(r')', r'\29')


### PR DESCRIPTION
Using in combination with [dogtag pki](https://github.com/dogtagpki/pki) I get the following error:

```
[root@pki /]# pki-server ca-cert-request-find --cert-file ca_s.pem 
ERROR: a bytes-like object is required, not 'str'
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/pki/server/pkiserver.py", line 41, in <module>
    cli.execute(sys.argv)
  File "/usr/lib/python3.11/site-packages/pki/server/cli/__init__.py", line 145, in execute
    super().execute(args)
  File "/usr/lib/python3.11/site-packages/pki/cli/__init__.py", line 217, in execute
    module.execute(module_args)
  File "/usr/lib/python3.11/site-packages/pki/cli/__init__.py", line 217, in execute
    module.execute(module_args)
  File "/usr/lib/python3.11/site-packages/pki/cli/__init__.py", line 217, in execute
    module.execute(module_args)
  [Previous line repeated 1 more time]
  File "/usr/lib/python3.11/site-packages/pki/server/cli/ca.py", line 642, in execute
    results = subsystem.find_cert_requests(cert=cert)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/pki/server/subsystem.py", line 2244, in find_cert_requests
    escaped_value = ldap.filter.escape_filter_chars(cert)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/site-packages/ldap/filter.py", line 41, in escape_filter_chars
    s = assertion_value.replace('\\', r'\5c')
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: a bytes-like object is required, not 'str'
```

This is on Fedora 38 and Python 3.11.4.

Converting to string solve the problem.