### PR TITLE
refactor: Use functions from limited API

### DIFF
--- a/Modules/ldapcontrol.c
+++ b/Modules/ldapcontrol.c
@@ -186,7 +186,7 @@ LDAPControls_to_List(LDAPControl **ldcs)
             Py_DECREF(res);
             return NULL;
         }
-        PyList_SET_ITEM(res, i, pyctrl);
+        PyList_SetItem(res, i, pyctrl);
     }
     return res;
 }

--- a/Modules/options.c
+++ b/Modules/options.c
@@ -183,8 +183,8 @@ LDAP_set_option(LDAPObject *self, int option, PyObject *value)
                     /* TypeError: mention either float or None is expected */
                     PyErr_Clear();
                     PyErr_Format(PyExc_TypeError,
-                                 "A float or None is expected for timeout, got %.100s",
-                                 Py_TYPE(value)->tp_name);
+                                 "A float or None is expected for timeout, got %S",
+                                 Py_TYPE(value));
                 }
                 return 0;
             }
@@ -302,9 +302,9 @@ LDAP_get_option(LDAPObject *self, int option)
             num_extensions++;
         extensions = PyTuple_New(num_extensions);
         for (i = 0; i < num_extensions; i++)
-            PyTuple_SET_ITEM(extensions, i,
-                             PyUnicode_FromString(apiinfo.ldapai_extensions
-                                                  [i]));
+            PyTuple_SetItem(extensions, i,
+                            PyUnicode_FromString(apiinfo.ldapai_extensions
+                                                 [i]));
 
         /* return api info as a dictionary */
         v = Py_BuildValue("{s:i, s:i, s:i, s:s, s:i, s:O}",


### PR DESCRIPTION
Replace unsafe macros and direct struct access with functions from the subset of limited API functions.

* `PySequence_Fast_GET_ITEM` -> `PySequence_GetItem`
* `PyTuple_SET_ITEM` -> `PyTuple_SetItem`
* `PyList_SET_ITEM` -> `PyList_SetItem`
* `PyUnicode_AsUTF8AndSize` -> `PyUnicode_AsUTF8String` + `PyBytes_AsStringAndSize`. The function `PyUnicode_AsUTF8AndSize` is not in limited API before Python 3.10.
* `const char *tp_name` -> `Py_TYPE()` string representation

See: https://github.com/python-ldap/python-ldap/issues/540