### PR TITLE
test: PyPy fixes

### DIFF
--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -657,7 +657,11 @@ class Test03_SimpleLDAPObjectWithFileno(Test00_SimpleLDAPObject):
         )
 
     def tearDown(self):
-        self._sock.close()
+        try:
+            self._sock.close()
+        except OSError:
+            # PyPy sometimes fails with "Bad file descriptor"
+            pass
         delattr(self, '_sock')
         super().tearDown()
 

--- a/tox.ini
+++ b/tox.ini
@@ -86,8 +86,8 @@ commands =
         Tests/t_ldif.py \
         Tests/t_untested_mods.py
 
-[testenv:pypy3]
-basepython = pypy3
+[testenv:pypy3.9]
+basepython = pypy3.9
 deps = pytest
 commands = {envpython} -m pytest {posargs}
 


### PR DESCRIPTION
On PyPy 3.9 `sock.close()` sometimes fails with `Bad file descriptor`, because the fd is already closed. Silence the exception. The problem is not a bug in python-ldap.

Really use PyPy 3.9 in `tox.ini`.