### PR TITLE
refactor: Port to multi-phase module init

### DIFF
--- a/Misc/python-ldap.supp
+++ b/Misc/python-ldap.supp
@@ -46,7 +46,7 @@
    fun:PyObject_Malloc
    ...
    fun:PyErr_NewException
-   fun:LDAPinit_constants
+   fun:LDAPMod_init_constants
    fun:init_ldap_module
    ...
 }

--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -1539,3 +1539,13 @@ PyTypeObject LDAP_Type = {
     0,                  /*tp_members */
     0,                  /*tp_getset */
 };
+
+int
+LDAPMod_init_type(PyObject *m)
+{
+    /* Initialize LDAP class */
+    if (PyType_Ready(&LDAP_Type) < 0) {
+        return -1;
+    }
+    return 0;
+}

--- a/Modules/common.c
+++ b/Modules/common.c
@@ -3,21 +3,6 @@
 
 #include "pythonldap.h"
 
-/* dynamically add the methods into the module dictionary d */
-
-void
-LDAPadd_methods(PyObject *d, PyMethodDef *methods)
-{
-    PyMethodDef *meth;
-
-    for (meth = methods; meth->ml_meth; meth++) {
-        PyObject *f = PyCFunction_New(meth, NULL);
-
-        PyDict_SetItemString(d, meth->ml_name, f);
-        Py_DECREF(f);
-    }
-}
-
 /* Raise TypeError with custom message and object */
 PyObject *
 LDAPerror_TypeError(const char *msg, PyObject *obj)

--- a/Modules/constants.c
+++ b/Modules/constants.c
@@ -192,7 +192,7 @@ LDAPerror(LDAP *l)
 /* initialise the module constants */
 
 int
-LDAPinit_constants(PyObject *m)
+LDAPMod_init_constants(PyObject *m)
 {
     PyObject *exc, *nobj;
     struct ldap_apifeature_info info = { 1, "X_OPENLDAP_THREAD_SAFE", 0 };

--- a/Modules/functions.c
+++ b/Modules/functions.c
@@ -4,8 +4,8 @@
 
 /* ldap_initialize */
 
-static PyObject *
-l_ldap_initialize(PyObject *unused, PyObject *args)
+PyObject *
+LDAPMod_initialize(PyObject *module, PyObject *args)
 {
     char *uri;
     LDAP *ld = NULL;
@@ -28,8 +28,8 @@ l_ldap_initialize(PyObject *unused, PyObject *args)
 #ifdef HAVE_LDAP_INIT_FD
 /* initialize_fd(fileno, url) */
 
-static PyObject *
-l_ldap_initialize_fd(PyObject *unused, PyObject *args)
+PyObject *
+LDAPMod_initialize_fd(PyObject *module, PyObject *args)
 {
     char *url;
     LDAP *ld = NULL;
@@ -82,8 +82,8 @@ l_ldap_initialize_fd(PyObject *unused, PyObject *args)
 
 /* ldap_str2dn */
 
-static PyObject *
-l_ldap_str2dn(PyObject *unused, PyObject *args)
+PyObject *
+LDAPMod_str2dn(PyObject *module, PyObject *args)
 {
     struct berval str;
     LDAPDN dn;
@@ -157,8 +157,8 @@ l_ldap_str2dn(PyObject *unused, PyObject *args)
 
 /* ldap_set_option (global options) */
 
-static PyObject *
-l_ldap_set_option(PyObject *self, PyObject *args)
+PyObject *
+LDAPMod_set_option(PyObject *module, PyObject *args)
 {
     PyObject *value;
     int option;
@@ -173,8 +173,8 @@ l_ldap_set_option(PyObject *self, PyObject *args)
 
 /* ldap_get_option (global options) */
 
-static PyObject *
-l_ldap_get_option(PyObject *self, PyObject *args)
+PyObject *
+LDAPMod_get_option(PyObject *module, PyObject *args)
 {
     int option;
 
@@ -184,22 +184,3 @@ l_ldap_get_option(PyObject *self, PyObject *args)
 }
 
 /* methods */
-
-static PyMethodDef methods[] = {
-    {"initialize", (PyCFunction)l_ldap_initialize, METH_VARARGS},
-#ifdef HAVE_LDAP_INIT_FD
-    {"initialize_fd", (PyCFunction)l_ldap_initialize_fd, METH_VARARGS},
-#endif
-    {"str2dn", (PyCFunction)l_ldap_str2dn, METH_VARARGS},
-    {"set_option", (PyCFunction)l_ldap_set_option, METH_VARARGS},
-    {"get_option", (PyCFunction)l_ldap_get_option, METH_VARARGS},
-    {NULL, NULL}
-};
-
-/* initialisation */
-
-void
-LDAPinit_functions(PyObject *d)
-{
-    LDAPadd_methods(d, methods);
-}

--- a/Modules/ldapcontrol.c
+++ b/Modules/ldapcontrol.c
@@ -194,8 +194,8 @@ LDAPControls_to_List(LDAPControl **ldcs)
 /* --------------- en-/decoders ------------- */
 
 /* Matched Values, aka, Values Return Filter */
-static PyObject *
-encode_rfc3876(PyObject *self, PyObject *args)
+PyObject *
+LDAPMod_encode_rfc3876(PyObject *module, PyObject *args)
 {
     PyObject *res = 0;
     int err;
@@ -235,8 +235,8 @@ encode_rfc3876(PyObject *self, PyObject *args)
     return res;
 }
 
-static PyObject *
-encode_rfc2696(PyObject *self, PyObject *args)
+PyObject *
+LDAPMod_encode_rfc2696(PyObject *module, PyObject *args)
 {
     PyObject *res = 0;
     BerElement *ber = 0;
@@ -291,8 +291,8 @@ encode_rfc2696(PyObject *self, PyObject *args)
     return res;
 }
 
-static PyObject *
-decode_rfc2696(PyObject *self, PyObject *args)
+PyObject *
+LDAPMod_decode_rfc2696(PyObject *module, PyObject *args)
 {
     PyObject *res = 0;
     BerElement *ber = 0;
@@ -328,8 +328,8 @@ decode_rfc2696(PyObject *self, PyObject *args)
     return res;
 }
 
-static PyObject *
-encode_assertion_control(PyObject *self, PyObject *args)
+PyObject *
+LDAPMod_encode_assertion_control(PyObject *module, PyObject *args)
 {
     int err;
     PyObject *res = 0;
@@ -373,18 +373,4 @@ encode_assertion_control(PyObject *self, PyObject *args)
   endlbl:
 
     return res;
-}
-
-static PyMethodDef methods[] = {
-    {"encode_page_control", encode_rfc2696, METH_VARARGS},
-    {"decode_page_control", decode_rfc2696, METH_VARARGS},
-    {"encode_valuesreturnfilter_control", encode_rfc3876, METH_VARARGS},
-    {"encode_assertion_control", encode_assertion_control, METH_VARARGS},
-    {NULL, NULL}
-};
-
-void
-LDAPinit_control(PyObject *d)
-{
-    LDAPadd_methods(d, methods);
 }

--- a/Modules/pythonldap.h
+++ b/Modules/pythonldap.h
@@ -55,8 +55,6 @@ LDAP_F(int) ldap_init_fd(ber_socket_t fd, int proto, LDAP_CONST char *url,
 
 PYLDAP_FUNC(PyObject *) LDAPerror_TypeError(const char *, PyObject *);
 
-PYLDAP_FUNC(void) LDAPadd_methods(PyObject *d, PyMethodDef *methods);
-
 #define PyNone_Check(o) ((o) == Py_None)
 
 /* *** berval *** */
@@ -64,7 +62,7 @@ PYLDAP_FUNC(PyObject *) LDAPberval_to_object(const struct berval *bv);
 PYLDAP_FUNC(PyObject *) LDAPberval_to_unicode_object(const struct berval *bv);
 
 /* *** constants *** */
-PYLDAP_FUNC(int) LDAPinit_constants(PyObject *m);
+PYLDAP_FUNC(int) LDAPMod_init_constants(PyObject *m);
 
 PYLDAP_DATA(PyObject *) LDAPexception_class;
 PYLDAP_FUNC(PyObject *) LDAPerror(LDAP *);
@@ -79,14 +77,14 @@ PYLDAP_FUNC(PyObject *) LDAPerr(int errnum);
 #define LDAP_CONTROL_VALUESRETURNFILTER "1.2.826.0.1.3344810.2.3"       /* RFC 3876 */
 #endif /* !LDAP_CONTROL_VALUESRETURNFILTER */
 
-/* *** functions *** */
-PYLDAP_FUNC(void) LDAPinit_functions(PyObject *);
-
 /* *** ldapcontrol *** */
-PYLDAP_FUNC(void) LDAPinit_control(PyObject *d);
 PYLDAP_FUNC(void) LDAPControl_List_DEL(LDAPControl **);
 PYLDAP_FUNC(int) LDAPControls_from_object(PyObject *, LDAPControl ***);
 PYLDAP_FUNC(PyObject *) LDAPControls_to_List(LDAPControl **ldcs);
+PYLDAP_FUNC(PyObject *) LDAPMod_encode_rfc2696(PyObject *, PyObject *);
+PYLDAP_FUNC(PyObject *) LDAPMod_decode_rfc2696(PyObject *, PyObject *);
+PYLDAP_FUNC(PyObject *) LDAPMod_encode_rfc3876(PyObject *, PyObject *);
+PYLDAP_FUNC(PyObject *) LDAPMod_encode_assertion_control(PyObject *, PyObject *);
 
 /* *** ldapobject *** */
 typedef struct {
@@ -97,6 +95,7 @@ typedef struct {
 
 PYLDAP_DATA(PyTypeObject) LDAP_Type;
 PYLDAP_FUNC(LDAPObject *) newLDAPObject(LDAP *);
+PYLDAP_FUNC(int) LDAPMod_init_type(PyObject *module);
 
 /* macros to allow thread saving in the context of an LDAP connection */
 
@@ -127,5 +126,14 @@ PYLDAP_FUNC(int) LDAP_set_option(LDAPObject *self, int option,
                                  PyObject *value);
 PYLDAP_FUNC(PyObject *) LDAP_get_option(LDAPObject *self, int option);
 PYLDAP_FUNC(void) set_timeval_from_double(struct timeval *tv, double d);
+
+/* *** functions *** */
+PYLDAP_FUNC(PyObject *) LDAPMod_initialize(PyObject *, PyObject *);
+#ifdef HAVE_LDAP_INIT_FD
+PYLDAP_FUNC(PyObject *) LDAPMod_initialize_fd(PyObject *, PyObject *);
+#endif
+PYLDAP_FUNC(PyObject *) LDAPMod_str2dn(PyObject *, PyObject *);
+PYLDAP_FUNC(PyObject *) LDAPMod_set_option(PyObject *, PyObject *);
+PYLDAP_FUNC(PyObject *) LDAPMod_get_option(PyObject *, PyObject *);
 
 #endif /* pythonldap_h */


### PR DESCRIPTION
The `_ldap` module now uses modern multi-phase module initialization.

Replace `LDAPadd_methods` hack with proper PyMethodDef for module-level functions. The old approache is incompatible with multi-phase init. Module-level functions are now prefixed with `LDAPMod_` and exported.

Use `PyModuleDef_Slot` to initialize the `_ldap` C extension.

See: https://github.com/python-ldap/python-ldap/issues/540