### PR TITLE
refactor: Port LDAP_Type to heap type

### DIFF
--- a/Modules/ldapmodule.c
+++ b/Modules/ldapmodule.c
@@ -41,7 +41,7 @@ PyInit__ldap()
     m = PyModule_Create(&ldap_moduledef);
 
     /* Initialize LDAP class */
-    if (PyType_Ready(&LDAP_Type) < 0) {
+    if (LDAPMod_init_type(m) < 0) {
         Py_DECREF(m);
         return NULL;
     }

--- a/Modules/pythonldap.h
+++ b/Modules/pythonldap.h
@@ -17,6 +17,11 @@
 #include <ldap.h>
 #include <ldap_features.h>
 
+#if PY_VERSION_HEX >= 0x030a0000 && (!defined(Py_LIMITED_API) || Py_LIMITED_API >= 0x030a0000)
+// Python 3.10 stable ABI introduced PyType_GetModuleState()
+#define HAVE_PYTYPE_GETMODULESTATE 1
+#endif
+
 #if LDAP_VENDOR_VERSION < 20400
 #error Current python-ldap requires OpenLDAP 2.4.x
 #endif
@@ -95,8 +100,9 @@ typedef struct {
     int valid;
 } LDAPObject;
 
-PYLDAP_DATA(PyTypeObject) LDAP_Type;
+PYLDAP_DATA(PyTypeObject *)LDAP_Type;
 PYLDAP_FUNC(LDAPObject *) newLDAPObject(LDAP *);
+PYLDAP_FUNC(int) LDAPMod_init_type(PyObject *module);
 
 /* macros to allow thread saving in the context of an LDAP connection */
 

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -240,6 +240,18 @@ class TestLdapCExtension(SlapdTestCase):
         else:
             self.assertTrue(_ldap.SASL_AVAIL)
 
+    def test_ldap_type(self):
+        ldap_type = type(self._open_conn())
+        # Python 3.10+ versions use qualified class name
+        self.assertIn(
+            repr(ldap_type),
+            ["<class 'LDAP'>", "<class '_ldap.LDAP'>"],
+        )
+        with self.assertRaisesRegex(
+            TypeError, "cannot create '.*LDAP' instances"
+        ):
+            ldap_type()
+
     def test_simple_bind(self):
         l = self._open_conn()
 


### PR DESCRIPTION
The `LDAP` type has been converted from a static type to a heap type. The limited API does not support static types.

Heap types behave more closely like Python classes. They are allocated on the heap and reference counted. Instances have a strong reference to their type and must use GC protocol to track this reference.

The LDAP type can no longer be instantiated by Python code. This was never supported and resulted in an invalid LDAP connection. Code like `type(_ldap.initialize(""))()" now fails with a `TypeError`.

See: https://github.com/python-ldap/python-ldap/issues/540