### PR TITLE
Update Docs on installation requirements

### DIFF
--- a/Doc/installing.rst
+++ b/Doc/installing.rst
@@ -143,10 +143,15 @@ Packages for building::
 Debian
 ------
 
+Packages for building::
+
+   # apt-get install build-essential ldap-utils \
+       libldap2-dev libsasl2-dev
+
 Packages for building and testing::
 
-   # apt-get install build-essential python3-dev \
-       libldap2-dev libsasl2-dev slapd ldap-utils tox \
+   # apt-get install build-essential ldap-utils \
+       libldap2-dev libsasl2-dev slapd python3-dev tox \
        lcov valgrind
 
 .. note::


### PR DESCRIPTION
This PR updates the documentation regarding the build prerequisites. Specifically, it separates build requirements from the ones needed for testing (for Debian).

I tested the build requirements with the following `Dockerfile` and it works.

```
FROM python:3.11

RUN apt-get update \
    && apt-get install -y build-essential ldap-utils \
    libldap2-dev libsasl2-dev \
    && rm -rf /var/lib/apt/lists/*
RUN pip install python-ldap==3.4.3
```
