### PR TITLE
Fix segfault in internal function _ldap.str2dn

### DIFF
--- a/Modules/functions.c
+++ b/Modules/functions.c
@@ -100,6 +100,11 @@ l_ldap_str2dn(PyObject *unused, PyObject *args)
      */
     if (!PyArg_ParseTuple(args, "z#|i:str2dn", &str.bv_val, &str_len, &flags))
         return NULL;
+
+    if (str_len == 0) {
+        // GH-549: ldap_bv2dn() does not support empty string.
+        return PyList_New(0);
+    }
     str.bv_len = (ber_len_t) str_len;
 
     res = ldap_bv2dn(&str, &dn, flags);

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -955,6 +955,12 @@ class TestLdapCExtension(SlapdTestCase):
             _ldap.OPT_X_TLS_TRY
         )
 
+    def test_str2dn(self):
+        self.assertEqual(_ldap.str2dn(""), [])
+        self.assertEqual(_ldap.str2dn(None), [])
+        with self.assertRaises(TypeError):
+            _ldap.str2dn(object)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`l_ldap_str2dn` crashes with a NULL pointer deref when an empty string or None is passed in. `ldap_bv2dn` returns success with NULL dn for an empty berval struct. In debug builds, `ldap_bv2dn` fails with an assertion error.

The function now returns an empty list for an empty input.

Note: The public API of python-ldap is not affected. The wrapper `ldap.dn.str2dn` does not pass an empty string to the low-level function.

Fixes: https://github.com/python-ldap/python-ldap/issues/549