### PR TITLE
docs: add missing negation in contributing.rst

### DIFF
--- a/Doc/contributing.rst
+++ b/Doc/contributing.rst
@@ -19,7 +19,7 @@ Communication
 
 Always keep in mind that python-ldap is developed and maintained by volunteers.
 We're happy to share our work, and to work with you to make the library better,
-but (until you pay someone), there's obligation to provide assistance.
+but (until you pay someone), there's no obligation to provide assistance.
 
 So, keep it friendly, respectful, and supportive!
 


### PR DESCRIPTION
Current description contains a sentence that miss a negative form, contradicting previous sentence and leaving the reader with an ambiguity.

---

I did not run the tests locally, as 1) the change is in documentation text only 2) this is a fork of current `main` branch, 3) I made the change online, using GitHub editor.