### PR TITLE
Fix(LDAPObject): Prevent search attrlist memory error

### DIFF
--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -288,7 +288,10 @@ attrs_from_List(PyObject *attrlist, char ***attrsp)
         if (seq == NULL)
             goto error;
 
-        len = PySequence_Length(attrlist);
+        len = PySequence_Size(seq);
+        if (len == -1) {
+            goto error;
+        }
 
         attrs = PyMem_NEW(char *, len + 1);
 

--- a/Tests/t_ldapobject.py
+++ b/Tests/t_ldapobject.py
@@ -478,6 +478,7 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
             [self.server.suffix.encode('utf-8')]
         )
 
+
     def test_compare_s_true(self):
         base = self.server.suffix
         l = self._ldap_conn
@@ -568,6 +569,38 @@ class Test00_SimpleLDAPObject(SlapdTestCase):
             ("objectClass", b'myClass'),
             ("myAttribute", b'foobar'),
         ])
+
+    def test_valid_attrlist_parameter_types(self):
+        """Tests the case when a valid parameter type is passed to search_ext
+
+        Any iterable which only contains strings should not raise any errors.
+        """
+
+        l = self._ldap_conn
+
+        valid_attrlist_parameters = [{"a": "2"}, ["a", "b"], {}, set(), set(["a", "b"])]
+
+        for attrlist in valid_attrlist_parameters:
+            out = l.search_ext(
+                "%s" % self.server.suffix, ldap.SCOPE_SUBTREE, attrlist=attrlist
+            )
+
+    def test_invalid_attrlist_parameter_types(self):
+        """Tests the case when an invalid parameter type is passed to search_ext
+
+        Any object type that is either not a interable or does contain something
+        that isn't a string should raise a TypeError. The exception is the string type itself.
+        """
+
+        invalid_attrlist_parameters = [{1: 2}, 0, object(), "string"]
+
+        l = self._ldap_conn
+
+        for attrlist in invalid_attrlist_parameters:
+            with self.assertRaises(TypeError):
+                l.search_ext(
+                    "%s" % self.server.suffix, ldap.SCOPE_SUBTREE, attrlist=attrlist
+                )
 
 
 class Test01_ReconnectLDAPObject(Test00_SimpleLDAPObject):


### PR DESCRIPTION
## Problem

Providing a dictionary to `attrlist` ([LDAPObject.search_ext](https://www.python-ldap.org/en/python-ldap-3.4.3/reference/ldap.html#ldap.LDAPObject.search_ext)) results in a memory error.

See Issue https://github.com/python-ldap/python-ldap/issues/556

## Root cause

Function `PySequence_Length` can return -1 on iterables like `dict`. The following PyMem_NEW still succeeds due `PyMem_NEW(char *, -1 + 1)` being equivalent to `char** PyMem_Malloc(1)`, which then can result in a
segmentation fault later on.
    
## Solution

The expected behavior should be either a raised `TypeError` or that any iterable which contains only strings can be passed.
Commit e18c567 enables the latter which is in itself very unlikely to break anything. I would actually prefer to raise a `TypeError` in the C extension on encountering a dictionary as it is most likely an error on the callers side, maybe we can add that later.

The fix in e18c567 is to use `seq` and `PySequence_Fast_GET_SIZE` to determine the size of the sequence. This way any iterable which contains only strings can be used. I added two tests in a1bdf47 which will fail without the fix in e18c567.