### PR TITLE
Fixes #565 - Use name values instead of raw decimal

### DIFF
--- a/Lib/ldap/syncrepl.py
+++ b/Lib/ldap/syncrepl.py
@@ -12,6 +12,7 @@ from pyasn1.codec.ber import encoder, decoder
 
 from ldap.pkginfo import __version__, __author__, __license__
 from ldap.controls import RequestControl, ResponseControl, KNOWN_RESPONSE_CONTROLS
+from ldap import RES_SEARCH_RESULT, RES_SEARCH_ENTRY, RES_INTERMEDIATE
 
 __all__ = [
     'SyncreplConsumer',
@@ -407,7 +408,7 @@ class SyncreplConsumer:
                 all=0,
             )
 
-            if type == 101:
+            if type == RES_SEARCH_RESULT:
                 # search result. This marks the end of a refreshOnly session.
                 # look for a SyncDone control, save the cookie, and if necessary
                 # delete non-present entries.
@@ -420,7 +421,7 @@ class SyncreplConsumer:
 
                 return False
 
-            elif type == 100:
+            elif type == RES_SEARCH_ENTRY:
                 # search entry with associated SyncState control
                 for m in msg:
                     dn, attrs, ctrls = m
@@ -439,7 +440,7 @@ class SyncreplConsumer:
                             self.syncrepl_set_cookie(c.cookie)
                         break
 
-            elif type == 121:
+            elif type == RES_INTERMEDIATE:
                 # Intermediate message. If it is a SyncInfoMessage, parse it
                 for m in msg:
                     rname, resp, ctrls = m


### PR DESCRIPTION
Use the name values for result types in syncrepl.py rather than the raw decimal values.