### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,9 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
           - "pypy3.9"
+          - "pypy3.10"
         image: 
           - "ubuntu-22.04"
         include:
@@ -43,7 +45,7 @@ jobs:
       - name: Disable AppArmor
         run: sudo aa-disable /usr/sbin/slapd
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/.github/workflows/tox-fedora.yml
+++ b/.github/workflows/tox-fedora.yml
@@ -9,7 +9,7 @@ jobs:
   tox_test:
     name: Tox env "${{matrix.tox_env}}" on Fedora
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Run Tox tests
       uses: fedora-python/tox-github-action@main
       with:
@@ -17,7 +17,7 @@ jobs:
         dnf_install: >
             @c-development openldap-devel python3-devel
             openldap-servers openldap-clients lcov clang-analyzer valgrind
-            enchant
+            enchant python3-setuptools
     strategy:
       matrix:
         tox_env:
@@ -28,6 +28,7 @@ jobs:
         - py310
         - py311
         - py312
+        - py313
         - c90-py36
         - c90-py37
         - py3-nosasltls

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     # Note: when updating Python versions, also change tox.ini and .github/workflows/*
 
     'Topic :: Database',

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ python =
     pypy3.10: pypy3.10
 
 [testenv]
-deps =
+deps = setuptools
 passenv = WITH_GCOV
 # - Enable BytesWarning
 # - Turn all warnings into exceptions.

--- a/tox.ini
+++ b/tox.ini
@@ -100,6 +100,7 @@ deps =
     markdown
     sphinx
     sphinxcontrib-spelling
+    setuptools
 commands =
     {envpython} setup.py check --restructuredtext --metadata --strict
     {envpython} -m markdown README -f {envtmpdir}/README.html

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,9 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
     pypy3.9: pypy3.9
+    pypy3.10: pypy3.10
 
 [testenv]
 deps =


### PR DESCRIPTION
Update GitHub Actions.
Explicitly install python3-setuptools for Tox env runs on Fedora.