### PR TITLE
feat(ldapobject): allow passing `uri=None` in `SimpleLDAPObject`

### DIFF
--- a/Lib/ldap/ldapobject.py
+++ b/Lib/ldap/ldapobject.py
@@ -67,7 +67,7 @@ class SimpleLDAPObject:
   }
 
   def __init__(
-    self,uri,
+    self,uri=None,
     trace_level=0,trace_file=None,trace_stack_limit=5,bytes_mode=None,
     bytes_strictness=None, fileno=None
   ):
@@ -848,7 +848,7 @@ class ReconnectLDAPObject(SimpleLDAPObject):
   _reconnect_exceptions = (ldap.SERVER_DOWN, ldap.UNAVAILABLE, ldap.CONNECT_ERROR, ldap.TIMEOUT)
 
   def __init__(
-    self,uri,
+    self,uri=None,
     trace_level=0,trace_file=None,trace_stack_limit=5,bytes_mode=None,
     bytes_strictness=None, retry_max=1, retry_delay=60.0, fileno=None
   ):


### PR DESCRIPTION
and `ReconnectLDAPObject` to be consistent with `initialize()`.

Followup for:
Fixes: 7af31254dcb22a58686cb140ac320af9a6f967fc
Issue: #465