### PR TITLE
fix(extop.dds): fix unset RefreshRequest.requestValue

### DIFF
--- a/Lib/ldap/extop/dds.py
+++ b/Lib/ldap/extop/dds.py
@@ -35,6 +35,7 @@ class RefreshRequest(ExtendedRequest):
     )
 
   def __init__(self,requestName=None,entryName=None,requestTtl=None):
+    super().__init__(requestName, b'')
     self.entryName = entryName
     self.requestTtl = requestTtl or self.defaultRequestTtl
 


### PR DESCRIPTION
```pycon
>>> from ldap.extop.dds import RefreshRequest
>>> req = RefreshRequest(RefreshRequest.requestName, 'uid=temp,dc=freeiam,dc=org', 86400)
>>> repr(req)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/ldap/extop/__init__.py", line 31, in __repr__
    return f'{self.__class__.__name__}({self.requestName},{self.requestValue})'
                                                           ^^^^^^^^^^^^^^^^^
AttributeError: 'RefreshRequest' object has no attribute 'requestValue'. Did you mean: 'requestName'?
```