### PR TITLE
Explicitly close url file to avoid ResourceWarning in Python 3.14

### DIFF
--- a/Lib/ldap/schema/subentry.py
+++ b/Lib/ldap/schema/subentry.py
@@ -476,10 +476,10 @@ def urlfetch(uri,trace_level=0):
     l.unbind_s()
     del l
   else:
-    ldif_file = urlopen(uri)
-    ldif_parser = ldif.LDIFRecordList(ldif_file,max_entries=1)
-    ldif_parser.parse()
-    subschemasubentry_dn,s_temp = ldif_parser.all_records[0]
+    with urlopen(uri) as ldif_file:
+      ldif_parser = ldif.LDIFRecordList(ldif_file,max_entries=1)
+      ldif_parser.parse()
+      subschemasubentry_dn,s_temp = ldif_parser.all_records[0]
   # Work-around for mixed-cased attribute names
   subschemasubentry_entry = ldap.cidict.cidict()
   s_temp = s_temp or {}


### PR DESCRIPTION
`urlopen` opens a file, when it's not closed explicitly it creates the following warning (at least with Python 3.14):
```
ResourceWarning: Implicitly cleaning up <addinfourl at 140737302018240 whose fp = <_io.BufferedReader name='/build/source/Tests/data/subschema-ipa.demo1.freeipa.org.ldif'>>
```

This makes the test suite fail if pytest has strict warning checks.

I found this through this build failure for the NixOS python-ldap package with Python 3.14: https://hydra.nixos.org/build/318165407/nixlog/2

See also https://github.com/NixOS/nixpkgs/issues/475732