### PR TITLE
fix(ldif): explicitly close sockets after fetching URLs

### DIFF
--- a/Lib/ldif.py
+++ b/Lib/ldif.py
@@ -373,7 +373,8 @@ class LDIFParser:
       if self._process_url_schemes:
         u = urlparse(url)
         if u[0] in self._process_url_schemes:
-          attr_value = urlopen(url).read()
+          with urlopen(url) as fd:
+            attr_value = fd.read()
     else:
       # All values should be valid ascii; we support UTF-8 as a
       # non-official, backwards compatibility layer.


### PR DESCRIPTION
fixes resource warnings in Python 3.14