### PR TITLE
fix: Clarify fd ownership and align tests

### DIFF
--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -45,13 +45,24 @@ This module defines the following functions:
    connect to an LDAP server. The *fileno* must either be a socket file
    descriptor as :class:`int` or a file-like object with a *fileno()* method
    that returns a socket file descriptor. The socket file descriptor must
-   already be connected. :class:`~ldap.ldapobject.LDAPObject` does not take
-   ownership of the file descriptor. It must be kept open during operations
-   and explicitly closed after the :class:`~ldap.ldapobject.LDAPObject` is
-   unbound. The internal connection type is determined from the URI, ``TCP``
-   for ``ldap://`` / ``ldaps://``, ``IPC`` (``AF_UNIX``) for ``ldapi://``.
-   The parameter is not available on macOS when python-ldap is compiled with system
+   already be connected. :class:`~ldap.ldapobject.LDAPObject` takes ownership of
+   the file descriptor on creation which must be left alone and will be
+   automatically closed after the :class:`~ldap.ldapobject.LDAPObject` is
+   unbound. The internal connection type is determined from the URI, ``TCP`` for
+   ``ldap://`` / ``ldaps://``, ``IPC`` (``AF_UNIX``) for ``ldapi://``. The
+   parameter is not available on macOS when python-ldap is compiled with system
    libldap, see :py:const:`INIT_FD_AVAIL`.
+
+   .. warning::
+
+      The documentation used to suggest (wrongly) that the object would not take
+      ownership of the file descriptor in *fileno*. It does. If using *fileno*,
+      detach the socket it came from as soon as you use it to obtain an instance
+      of :class:`~ldap.ldapobject.LDAPObject`::
+
+         sock = socket.create_connection((host, port))
+         conn = ldap.initialize(uri, fileno=sock.fileno())
+         sock.detach()
 
    Note that internally the OpenLDAP function
    `ldap_initialize(3) <https://www.openldap.org/software/man.cgi?query=ldap_init&sektion=3>`_

--- a/Lib/ldap/functions.py
+++ b/Lib/ldap/functions.py
@@ -83,7 +83,9 @@ def initialize(
         Whether to enable :ref:`bytes_mode` for backwards compatibility under Py2.
   fileno
         If not None the socket file descriptor is used to connect to an
-        LDAP server.
+        LDAP server. The connection takes ownership of the descriptor and
+        closes it when unbound, so nothing else may close it. Detach the
+        socket object it came from.
 
   Additional keyword arguments (such as ``bytes_strictness``) are
   passed to ``LDAPObject``.

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -100,15 +100,13 @@ class TestLdapCExtension(SlapdTestCase):
         )
         try:
             l = _ldap.initialize_fd(sock.fileno(), self.server.ldap_uri)
-            if bind:
-                self._bind_conn(l)
-            yield sock, l
-        finally:
-            try:
-                sock.close()
-            except OSError:
-                # already closed
-                pass
+        except Exception:
+            sock.close()
+            raise
+        fd = sock.detach()
+        if bind:
+            self._bind_conn(l)
+        yield fd, l
 
     def _bind_conn(self, l):
         # Perform a simple bind
@@ -244,27 +242,32 @@ class TestLdapCExtension(SlapdTestCase):
         l = self._open_conn()
 
     def test_simple_bind_fileno(self):
-        with self._open_conn_fd() as (sock, l):
+        with self._open_conn_fd() as (fd, l):
             self.assertEqual(l.whoami_s(), "dn:" + self.server.root_dn)
 
     @requires_init_fd()
     def test_simple_bind_fileno_invalid(self):
-        with open(os.devnull) as f:
-            l = _ldap.initialize_fd(f.fileno(), self.server.ldap_uri)
-            with self.assertRaises(_ldap.SERVER_DOWN):
-                self._bind_conn(l)
+        fd = os.open(os.devnull, os.O_RDWR)
+        l = _ldap.initialize_fd(fd, self.server.ldap_uri)
+        with self.assertRaises(_ldap.SERVER_DOWN):
+            self._bind_conn(l)
+        l.unbind_ext()
 
     @requires_init_fd()
     def test_simple_bind_fileno_closed(self):
-        with self._open_conn_fd() as (sock, l):
+        with self._open_conn_fd() as (fd, l):
             self.assertEqual(l.whoami_s(), "dn:" + self.server.root_dn)
-            sock.close()
+
+            sock = socket.socket(fileno=fd)
+            sock.shutdown(socket.SHUT_RDWR)
+            sock.detach()
+
             with self.assertRaises(_ldap.SERVER_DOWN):
                 l.whoami_s()
 
     @requires_init_fd()
     def test_simple_bind_fileno_rebind(self):
-        with self._open_conn_fd() as (sock, l):
+        with self._open_conn_fd() as (fd, l):
             self.assertEqual(l.whoami_s(), "dn:" + self.server.root_dn)
             l.unbind_ext()
             with self.assertRaises(_ldap.LDAPError):


### PR DESCRIPTION
This should fix last of the pypy test failures.