### PR TITLE
fix(message): prevent segfault on invalid UTF-8

### DIFF
--- a/Modules/message.c
+++ b/Modules/message.c
@@ -90,6 +90,17 @@ LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls,
             struct berval **bvals;
 
             pyattr = PyUnicode_FromString(attr);
+            if (pyattr == NULL) {
+                Py_DECREF(attrdict);
+                Py_DECREF(result);
+                if (ber != NULL)
+                    ber_free(ber, 0);
+                ldap_msgfree(m);
+                ldap_memfree(attr);
+                ldap_memfree(dn);
+                Py_XDECREF(pyctrls);
+                return NULL;
+            }
 
             bvals = ldap_get_values_len(ld, entry, attr);
 
@@ -217,6 +228,14 @@ LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls,
             for (i = 0; refs[i] != NULL; i++) {
                 /* A referal is a distinguishedName => unicode */
                 PyObject *refstr = PyUnicode_FromString(refs[i]);
+                if (refstr == NULL) {
+                    Py_DECREF(reflist);
+                    Py_DECREF(result);
+                    ber_memvfree((void **)refs);
+                    ldap_msgfree(m);
+                    Py_XDECREF(pyctrls);
+                    return NULL;
+                }
 
                 PyList_Append(reflist, refstr);
                 Py_DECREF(refstr);


### PR DESCRIPTION
During fuzzing, two segfaults were found in `LDAPmessage_to_python()` due to unchecked failures from `PyUnicode_FromString()`. Other uses of `PyUnicode_FromString()` in this function already check for `NULL` before using the returned object. Valgrind logs were captured against python-ldap 3.4.5. The current `main` branch exhibits the same crash behavior. 

Although such malformed UTF-8 is not expected from a compliant LDAP server, untrusted server input should not be able to crash the Python interpreter.

## 1. PyDict_Contains
`LDAPmessage_to_python()` did not check the return value of `PyUnicode_FromString(attr)`. Invalid UTF-8 in an attribute name therefore resulted in a NULL pointer being passed to `PyDict_Contains()`, crashing the interpreter.

A part of valgrind log:
```
==15189== Process terminating with default action of signal 11 (SIGSEGV): dumping core
==15189==  Access not within mapped region at address 0x8
==15189==    at 0x49AACAC: Py_TYPE (object.h:336)
==15189==    by 0x49AACAC: Py_IS_TYPE (object.h:369)
==15189==    by 0x49AACAC: _PyObject_HashFast (pycore_object.h:732)
==15189==    by 0x49AACAC: PyDict_Contains (dictobject.c:4706)
==15189==    by 0x13FD2262: LDAPmessage_to_python (message.c:101)
==15189==    by 0x13FD31AC: l_ldap_result4 (LDAPObject.c:1186)
```

## 2. Py_DECREF
`LDAPmessage_to_python()` did not check the return value of `PyUnicode_FromString()` for referral URLs. Invalid UTF-8 therefore left `refstr == NULL`; after the ignored `PyList_Append()` failure, `Py_DECREF(refstr)` crashed the interpreter.

A part of valgrind log:
```
==15073== Process terminating with default action of signal 11 (SIGSEGV): dumping core
==15073==  Access not within mapped region at address 0x0
==15073==    at 0x13FD2864: _Py_IsImmortal (object.h:361)
==15073==    by 0x13FD2864: Py_DECREF (object.h:944)
==15073==    by 0x13FD2864: LDAPmessage_to_python (message.c:226)
==15073==    by 0x13FD31AC: l_ldap_result4 (LDAPObject.c:1186)
```

## Reproduction script

```
#!/usr/bin/env python3


import socket
import threading
import time

import ldap

# msgid=1, SearchResultEntry: DN="", one attribute, type="\x93", empty value set
ENTRY = bytes([
    0x30, 0x10,          # SEQUENCE, len 16
    0x02, 0x01, 0x01,    #   msgid = 1
    0x64, 0x0b,          #   [APP 4] SearchResultEntry, len 11
    0x04, 0x00,          #     DN = ""
    0x30, 0x07,          #     attributes SEQUENCE, len 7
    0x30, 0x05,          #       attr SEQUENCE, len 5
    0x04, 0x01, 0x93,    #         type = "\x93" (invalid UTF-8)
    0x31, 0x00,          #         vals SET (empty)
])

# msgid=1, SearchResultReference: single URL "\x93"
REF = bytes([
    0x30, 0x08,          # SEQUENCE, len 8
    0x02, 0x01, 0x01,    #   msgid = 1
    0x73, 0x03,          #   [APP 19] SearchResultReference, len 3
    0x04, 0x01, 0x93,    #     URL = "\x93"
])

DONE = bytes([
    0x30, 0x0c, 0x02, 0x01, 0x01, 0x65, 0x07,
    0x0a, 0x01, 0x00, 0x04, 0x00, 0x04, 00,
])


def serve(srv):
    conn, _ = srv.accept()
    conn.recv(4096)
    conn.sendall(REF + DONE) # another error place
    # conn.sendall(ENTRY + DONE)
    time.sleep(2)
    conn.close()


def main():
    srv = socket.socket()
    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
    srv.bind(("127.0.0.1", 0))
    srv.listen(1)
    threading.Thread(target=serve, args=(srv,), daemon=True).start()

    conn = ldap.initialize(f"ldap://127.0.0.1:{srv.getsockname()[1]}/")
    conn.search_ext_s("dc=example,dc=com", ldap.SCOPE_SUBTREE, 
                      "(objectClass=*)", ["*"])
    print("no crash — bug fixed?")


if __name__ == "__main__":
    main()
```