### PR TITLE
Fixing reference leaks

### DIFF
--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -170,6 +170,7 @@ Tuple_to_LDAPMod(PyObject *tup, int no_op)
                 LDAPerror_TypeError
                     ("Tuple_to_LDAPMod(): expected a byte string in the list",
                      item);
+                Py_DECREF(item);
                 goto error;
             }
             lm->mod_bvalues[i]->bv_len = PyBytes_Size(item);

--- a/Modules/LDAPObject.c
+++ b/Modules/LDAPObject.c
@@ -611,8 +611,10 @@ interaction(unsigned flags, sasl_interact_t *interact, PyObject *SASLObject)
        fixed sometimes.
      */
     interact->result = strdup(c_result);
-    if (interact->result == NULL)
+    if (interact->result == NULL) {
+        Py_DECREF(result);
         return LDAP_OPERATIONS_ERROR;
+    }
     interact->len = strlen(c_result);
     /* We _should_ overwrite the python string buffer for security
        reasons, however we may not (api/stringObjects.html). Any ideas?

--- a/Modules/constants.c
+++ b/Modules/constants.c
@@ -214,12 +214,12 @@ LDAPinit_constants(PyObject *m)
     }
 
     if (PyModule_AddObject(m, "LDAPError", LDAPexception_class) != 0)
-        return -1;
+        goto error;
     Py_INCREF(LDAPexception_class);
 
     /* XXX - backward compatibility with pre-1.8 */
     if (PyModule_AddObject(m, "error", LDAPexception_class) != 0)
-        return -1;
+        goto error;
     Py_INCREF(LDAPexception_class);
 
 #ifdef LDAP_API_FEATURE_X_OPENLDAP_THREAD_SAFE
@@ -228,39 +228,53 @@ LDAPinit_constants(PyObject *m)
     }
 #endif
     if (PyModule_AddIntConstant(m, "LIBLDAP_R", thread_safe) != 0)
-        return -1;
+        goto error;
 
     if (ldap_get_option(NULL, LDAP_OPT_API_INFO, &ldap_version_info) != LDAP_SUCCESS) {
         PyErr_SetString(PyExc_ImportError, "unrecognised libldap version");
-        return -1;
+        goto error;
     }
     if (PyModule_AddIntConstant(m, "_VENDOR_VERSION_RUNTIME",
                 ldap_version_info.ldapai_vendor_version ) != 0)
-        return -1;
+        goto error;
 
     /* Generated constants -- see Lib/ldap/constants.py */
 
 #define add_err(n) do {  \
     exc = PyErr_NewException("ldap." #n, LDAPexception_class, NULL);  \
-    if (exc == NULL) return -1;  \
+    if (exc == NULL) goto error; \
     nobj = PyLong_FromLong(LDAP_##n); \
-    if (nobj == NULL) return -1; \
-    if (PyObject_SetAttrString(exc, "errnum", nobj) != 0) return -1; \
+    if (nobj == NULL) { \
+        Py_DECREF(exc); \
+        goto error; \
+    } \
+    if (PyObject_SetAttrString(exc, "errnum", nobj) != 0) { \
+        Py_DECREF(nobj); \
+        Py_DECREF(exc); \
+        goto error; \
+    } \
     Py_DECREF(nobj); \
     errobjects[LDAP_##n+LDAP_ERROR_OFFSET] = exc;  \
-    if (PyModule_AddObject(m, #n, exc) != 0) return -1;  \
+    if (PyModule_AddObject(m, #n, exc) != 0) { \
+        Py_DECREF(exc); \
+        goto error; \
+    } \
     Py_INCREF(exc);  \
 } while (0)
 
 #define add_int(n) do {  \
-    if (PyModule_AddIntConstant(m, #n, LDAP_##n) != 0) return -1;  \
+    if (PyModule_AddIntConstant(m, #n, LDAP_##n) != 0) goto error; \
 } while (0)
 
 #define add_string(n) do {  \
-    if (PyModule_AddStringConstant(m, #n, LDAP_##n) != 0) return -1;  \
+    if (PyModule_AddStringConstant(m, #n, LDAP_##n) != 0) goto error; \
 } while (0)
 
 #include "constants_generated.h"
 
     return 0;
+
+error:
+    Py_CLEAR(LDAPexception_class);
+    return -1;
 }

--- a/Modules/constants.c
+++ b/Modules/constants.c
@@ -138,6 +138,7 @@ LDAPraise_for_message(LDAP *l, LDAPMessage *m)
         if (!(pyctrls = LDAPControls_to_List(serverctrls))) {
             int err = LDAP_NO_MEMORY;
 
+            Py_DECREF(info);
             ldap_set_option(l, LDAP_OPT_ERROR_NUMBER, &err);
             ldap_memfree(matched);
             ldap_memfree(error);

--- a/Modules/functions.c
+++ b/Modules/functions.c
@@ -139,6 +139,7 @@ l_ldap_str2dn(PyObject *unused, PyObject *args)
 
             if (PyList_Append(rdnlist, tuple) == -1) {
                 Py_DECREF(tuple);
+                Py_DECREF(rdnlist);
                 goto failed;
             }
             Py_DECREF(tuple);

--- a/Modules/message.c
+++ b/Modules/message.c
@@ -63,6 +63,7 @@ LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls,
         rc = ldap_get_entry_controls(ld, entry, &serverctrls);
         if (rc) {
             Py_DECREF(result);
+            Py_DECREF(attrdict);
             ldap_msgfree(m);
             ldap_memfree(dn);
             return LDAPerror(ld);
@@ -74,6 +75,7 @@ LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls,
 
             ldap_set_option(ld, LDAP_OPT_ERROR_NUMBER, &err);
             Py_DECREF(result);
+            Py_DECREF(attrdict);
             ldap_msgfree(m);
             ldap_memfree(dn);
             ldap_controls_free(serverctrls);
@@ -161,6 +163,7 @@ LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls,
         pydn = PyUnicode_FromString(dn);
         if (pydn == NULL) {
             Py_DECREF(result);
+            Py_DECREF(attrdict);
             ldap_msgfree(m);
             ldap_memfree(dn);
             return NULL;
@@ -271,6 +274,7 @@ LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls,
                 ber_bvfree(retdata);
                 if (valuestr == NULL) {
                     ldap_memfree(retoid);
+                    Py_DECREF(pyctrls);
                     Py_DECREF(result);
                     ldap_msgfree(m);
                     return NULL;
@@ -280,6 +284,7 @@ LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls,
                 ldap_memfree(retoid);
                 if (pyoid == NULL) {
                     Py_DECREF(valuestr);
+                    Py_DECREF(pyctrls);
                     Py_DECREF(result);
                     ldap_msgfree(m);
                     return NULL;
@@ -287,6 +292,9 @@ LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls,
 
                 valtuple = Py_BuildValue("(NNN)", pyoid, valuestr, pyctrls);
                 if (valtuple == NULL) {
+                    Py_DECREF(pyoid);
+                    Py_DECREF(valuestr);
+                    Py_DECREF(pyctrls);
                     Py_DECREF(result);
                     ldap_msgfree(m);
                     return NULL;

--- a/Modules/message.c
+++ b/Modules/message.c
@@ -137,11 +137,12 @@ LDAPmessage_to_python(LDAP *ld, LDAPMessage *m, int add_ctrls,
                     PyObject *valuestr;
 
                     valuestr = LDAPberval_to_object(bvals[i]);
-                    if (PyList_Append(valuelist, valuestr) == -1) {
+                    if (valuestr == NULL ||
+                            PyList_Append(valuelist, valuestr) == -1) {
                         Py_DECREF(pyattr);
                         Py_DECREF(attrdict);
                         Py_DECREF(result);
-                        Py_DECREF(valuestr);
+                        Py_XDECREF(valuestr);
                         Py_DECREF(valuelist);
                         if (ber != NULL)
                             ber_free(ber, 0);


### PR DESCRIPTION
(Might we willing to squash the series into a single commit.)

Picking up items from issues 617-622, plus independently anything picked up by the following coccinelle patch (minus false positives):

```cocci
/*
 * Run as
 * spatch --dir Modules -D report --no-show-diff --very-quiet --sp-file leaks.cocci
 */

virtual report

@r exists@
identifier alloc;
PyObject *obj;
identifier label;
position p;
@@

obj = alloc(...)
... when != return ...;
    when != obj;
(
  if (<+... obj == NULL ...+>) { ... return ...; }
|
  if (<+... obj == NULL ...+>) return ...;
|
  if (<+... obj == NULL ...+>) { ... goto label; }
|
  if (<+... obj == NULL ...+>) goto label;
)
... when != Py_DECREF(obj)
    when != Py_XDECREF(obj)
    when != Py_CLEAR(obj)
    when != obj = ...
    when != return obj;
(
  return obj;
|
  return@p ...;
)

@script:python depends on report@
p << r.p;
obj << r.obj;
alloc << r.alloc;
@@

msg = "leaked '%s' from %s()" % (obj, alloc)
coccilib.report.print_report(p[0], msg)

```