### PR TITLE
fix(_ldap): correct handling of empty string in _ldap.str2dn

### DIFF
--- a/Modules/functions.c
+++ b/Modules/functions.c
@@ -98,7 +98,7 @@ l_ldap_str2dn(PyObject *unused, PyObject *args)
      * ((('a','b',1),('c','d',1)),(('e','f',1),))
      * The integers are a bit combination of the AVA_* flags
      */
-    if (!PyArg_ParseTuple(args, "z#|i:str2dn", &str.bv_val, &str_len, &flags))
+    if (!PyArg_ParseTuple(args, "s#|i:str2dn", &str.bv_val, &str_len, &flags))
         return NULL;
     str.bv_len = (ber_len_t) str_len;
 
@@ -110,7 +110,7 @@ l_ldap_str2dn(PyObject *unused, PyObject *args)
     if (!tmp)
         goto failed;
 
-    for (i = 0; dn[i]; i++) {
+    for (i = 0; dn && dn[i]; i++) {
         LDAPRDN rdn;
         PyObject *rdnlist;
 

--- a/Tests/t_cext.py
+++ b/Tests/t_cext.py
@@ -981,6 +981,13 @@ class TestLdapCExtension(SlapdTestCase):
             _ldap.OPT_X_TLS_TRY
         )
 
+    def test_str2dn(self):
+        self.assertEqual(_ldap.str2dn(""), [])
+        with self.assertRaises(TypeError):
+            _ldap.str2dn(None)
+        with self.assertRaises(TypeError):
+            _ldap.str2dn(object)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tests/t_ldap_dn.py
+++ b/Tests/t_ldap_dn.py
@@ -21,6 +21,7 @@ class TestDN(unittest.TestCase):
         """
         test function is_dn()
         """
+        self.assertEqual(ldap.dn.is_dn(''), True)
         self.assertEqual(ldap.dn.is_dn('foobar,ou=ae-dir'), False)
         self.assertEqual(ldap.dn.is_dn('-cn=foobar,ou=ae-dir'), False)
         self.assertEqual(ldap.dn.is_dn(';cn=foobar,ou=ae-dir'), False)
@@ -57,7 +58,10 @@ class TestDN(unittest.TestCase):
         test function str2dn()
         """
         self.assertEqual(ldap.dn.str2dn(''), [])
+        self.assertEqual(ldap.dn.str2dn('', flags=ldap.DN_FORMAT_LDAPV3), [])
         self.assertEqual(ldap.dn.str2dn(None), [])
+        self.assertEqual(ldap.dn.str2dn(None, flags=ldap.DN_FORMAT_LDAPV3), [])
+
         self.assertEqual(
             ldap.dn.str2dn('uid=test42,ou=Testing,dc=example,dc=com'),
             [
@@ -134,6 +138,8 @@ class TestDN(unittest.TestCase):
         test function dn2str()
         """
         self.assertEqual(ldap.dn.dn2str([]), '')
+        self.assertEqual(ldap.dn.dn2str([], ldap.DN_FORMAT_LDAPV3), '')
+
         self.assertEqual(
             ldap.dn.dn2str([
                 [('uid', 'test42', 1)],
@@ -373,7 +379,11 @@ class TestDN(unittest.TestCase):
         """
         test function explode_dn()
         """
+        self.assertEqual(ldap.dn.explode_dn(None), [])
+        self.assertEqual(ldap.dn.explode_dn(None, flags=ldap.DN_FORMAT_LDAPV3), [])
+
         self.assertEqual(ldap.dn.explode_dn(''), [])
+        self.assertEqual(ldap.dn.explode_dn('', flags=ldap.DN_FORMAT_LDAPV3), [])
         self.assertEqual(
             ldap.dn.explode_dn('uid=test42,ou=Testing,dc=example,dc=com'),
             ['uid=test42', 'ou=Testing', 'dc=example', 'dc=com']
@@ -407,7 +417,11 @@ class TestDN(unittest.TestCase):
         """
         test function explode_rdn()
         """
+        self.assertEqual(ldap.dn.explode_rdn(None), [])
+        self.assertEqual(ldap.dn.explode_rdn(None, flags=ldap.DN_FORMAT_LDAPV3), [])
+
         self.assertEqual(ldap.dn.explode_rdn(''), [])
+        self.assertEqual(ldap.dn.explode_rdn('', flags=ldap.DN_FORMAT_LDAPV3), [])
         self.assertEqual(
             ldap.dn.explode_rdn('uid=test42'),
             ['uid=test42']


### PR DESCRIPTION
An alternative approach to fixing #549
