### PR TITLE
Fix 3.4 packaging

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,16 @@
+Released 3.4.8 (unreleased)
+
+Infrastructure:
+* Build requirement pinned to ``setuptools>=61``: older setuptools ignores
+  the PEP 621 ``[project]`` table and produces an sdist with broken metadata
+  (``Name: unknown``), which made pip silently fall back to ancient releases
+  when building 3.4.5 from source (#616). Old environments now fail with a
+  clear resolver error instead.
+* Removed the ``[install]`` section (``compile``/``optimize``) from
+  ``setup.cfg``; it caused ``bdist_wheel`` to embed ``__pycache__``
+  byte-code files in published wheels (#615).
+
+----------------------------------------------------------------
 Released 3.4.7 2026-05-19
 
 No code changes, correcting for the fact that the previous release artifacts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [build-system]
 requires = [
-    "setuptools",
+    # PEP 621 [project] metadata needs setuptools >= 61; older versions
+    # silently ignore the [project] table and build an sdist whose metadata
+    # name is "unknown" (the broken 3.4.5 release, #616).
+    "setuptools>=61",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,11 +27,6 @@ extra_objects =
 # Support for StartTLS/LDAPS, SASL bind and reentrant libldap_r.
 #libs = ldap_r lber
 
-# Installation options
-[install]
-compile = 1
-optimize = 1
-
 # Linux distributors/packagers should adjust these settings
 [bdist_rpm]
 provides = python-ldap


### PR DESCRIPTION
Two small packaging fixes for the 3.4 branch that I'd like in 3.4.8.

1. Pin the build requirement to setuptools>=61. The branch uses PEP 621 metadata, but setuptools older than 61 ignores the [project] table and builds artifacts with Name: UNKNOWN. That is how #616 happened: pip on Python 3.6 built the sdist with setuptools 59.6, discarded the result and quietly fell back to 3.4.4-era releases, which predate the 3.4.5 security fixes.

The trade-off: setuptools 61 needs Python 3.7, so 3.6 users now get a clear resolver error instead of a build. I think that beats the silent fallback, and it is why I did not bump requires-python instead; that would just make pip skip 3.4.8 and restart the same cascade via 3.4.7. Nothing changes for 3.7+ with default pip, and CI only tests 3.9+ anyway.

2. Remove the [install] section from setup.cfg. compile/optimize leak into bdist_wheel, so every wheel built from the sdist ships slapdtest/__pycache__/*.opt-1.pyc (#615).

Also starts a "Released 3.4.8 (unreleased)" CHANGES section covering both (I can remove it or rebase, if something is already ready)

Verified with python -m build in a clean venv: PKG-INFO has Name: python-ldap and Requires-Python: >=3.6, and the built wheel contains no __pycache__ entries.

main needs a different fix (setuptools>=77 for its PEP 639 metadata), so both issues stay open.
