### PR TITLE
fix(_ldap): plug error handling leaks

### DIFF
--- a/Modules/functions.c
+++ b/Modules/functions.c
@@ -251,6 +251,7 @@ l_ldap_dn2str(PyObject *self, PyObject *args)
             PyErr_NoMemory();
             goto error_cleanup;
         }
+        dn[i] = rdn;
 
         for (j = 0; j < navas; j++) {
             py_ava_item = PySequence_GetItem(py_rdn_seq, j);  /* New reference */
@@ -286,10 +287,10 @@ l_ldap_dn2str(PyObject *self, PyObject *args)
                 PyErr_NoMemory();
                 goto error_cleanup;
             }
+            rdn[j] = ava;
 
             ava->la_attr.bv_val = (char *)malloc((size_t)name_len + 1);
             if (ava->la_attr.bv_val == NULL) {
-                free(ava);
                 PyErr_NoMemory();
                 goto error_cleanup;
             }
@@ -299,8 +300,6 @@ l_ldap_dn2str(PyObject *self, PyObject *args)
 
             ava->la_value.bv_val = (char *)malloc((size_t)value_len + 1);
             if (ava->la_value.bv_val == NULL) {
-                free(ava->la_attr.bv_val);
-                free(ava);
                 PyErr_NoMemory();
                 goto error_cleanup;
             }
@@ -311,13 +310,9 @@ l_ldap_dn2str(PyObject *self, PyObject *args)
             ava->la_flags = (int)PyLong_AsLong(py_encoding);
             if (PyErr_Occurred()) {
                 /* Encoding conversion failed */
-                free(ava->la_attr.bv_val);
-                free(ava->la_value.bv_val);
-                free(ava);
                 goto error_cleanup;
             }
 
-            rdn[j] = ava;
             Py_DECREF(py_ava_item);
             py_ava_item = NULL;
         }
@@ -325,7 +320,6 @@ l_ldap_dn2str(PyObject *self, PyObject *args)
         /* Null‐terminate the RDN */
         rdn[navas] = NULL;
 
-        dn[i] = rdn;
         Py_DECREF(py_rdn_seq);
         py_rdn_seq = NULL;
     }


### PR DESCRIPTION
Adjustments to #466, `_free_dn_structure()` is tolerant to partially populated structures, so optimistic registration is viable and simplifies error handling.