### PR TITLE
fix(_ldap): remove deprecated OPT_X_TLS option

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 Released 3.5.0 (unreleased)
 
+API changes:
+* The deprecated ``OPT_X_TLS`` option has been removed, as announced in the
+  3.4.3 release notes. The ``OPT_X_TLS_*`` option constants (such as
+  ``OPT_X_TLS_NEWCTX`` and ``OPT_X_TLS_REQUIRE_CERT``) are unaffected.
+
 Infrastructure:
 * Building from source now requires setuptools >= 77, needed for the
   PEP 639 license metadata in ``pyproject.toml``

--- a/Doc/reference/ldap.rst
+++ b/Doc/reference/ldap.rst
@@ -488,12 +488,6 @@ TLS options
 
    get/set path to /dev/urandom (**DO NOT USE**)
 
-.. py:data:: OPT_X_TLS
-
-   .. deprecated:: 3.3.0
-      The option is deprecated in OpenLDAP and should no longer be used. It
-      will be removed in the future.
-
 .. note::
 
    OpenLDAP supports several TLS/SSL libraries. OpenSSL is the most common

--- a/Lib/ldap/constants.py
+++ b/Lib/ldap/constants.py
@@ -267,7 +267,6 @@ CONSTANTS = (
 
     Int('OPT_DEFBASE', optional=True),
 
-    TLSInt('OPT_X_TLS', optional=True),
     TLSInt('OPT_X_TLS_CTX'),
     TLSInt('OPT_X_TLS_CACERTFILE'),
     TLSInt('OPT_X_TLS_CACERTDIR'),

--- a/Modules/constants_generated.h
+++ b/Modules/constants_generated.h
@@ -202,11 +202,6 @@ add_int(OPT_DEFBASE);
 
 
 #if HAVE_TLS
-
-#if defined(LDAP_OPT_X_TLS)
-add_int(OPT_X_TLS);
-#endif
-
 add_int(OPT_X_TLS_CTX);
 add_int(OPT_X_TLS_CACERTFILE);
 add_int(OPT_X_TLS_CACERTDIR);

--- a/Modules/options.c
+++ b/Modules/options.c
@@ -82,7 +82,6 @@ LDAP_set_option(LDAPObject *self, int option, PyObject *value)
     case LDAP_OPT_ERROR_NUMBER:
     case LDAP_OPT_DEBUG_LEVEL:
 #ifdef HAVE_TLS
-    case LDAP_OPT_X_TLS:
     case LDAP_OPT_X_TLS_REQUIRE_CERT:
 #ifdef LDAP_OPT_X_TLS_CRLCHECK
     case LDAP_OPT_X_TLS_CRLCHECK:
@@ -334,7 +333,6 @@ LDAP_get_option(LDAPObject *self, int option)
     case LDAP_OPT_DEBUG_LEVEL:
     case LDAP_OPT_DESC:
 #ifdef HAVE_TLS
-    case LDAP_OPT_X_TLS:
     case LDAP_OPT_X_TLS_REQUIRE_CERT:
 #ifdef LDAP_OPT_X_TLS_CRLCHECK
     case LDAP_OPT_X_TLS_CRLCHECK:


### PR DESCRIPTION
The option was deprecated in OpenLDAP and first removed in python-ldap 3.4.2 (#67), then temporarily brought back in 3.4.3 (#480) with release notes promising its removal in 3.5.0. Follow through on that promise: drop the constant, its handling in get/set_option, and its documentation. The OPT_X_TLS_* option constants are unaffected.

Fixes: #637